### PR TITLE
Add Electron desktop app packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,27 @@ Open:
 http://127.0.0.1:3000/
 ```
 
+## Desktop App (Electron)
+
+Run SketchForge as a native desktop app on Windows, macOS, or Linux. 
+
+```bash
+npm install
+npm run electron:dev      # build the static export and open it in Electron
+```
+
+Package installers (Windows NSIS / macOS DMG / Linux AppImage) go to
+`deploy/electron/dist/`:
+
+```bash
+npm run electron:dist        # current platform
+npm run electron:dist:win    # Windows
+npm run electron:dist:mac    # macOS
+npm run electron:dist:linux  # Linux
+```
+
+See [`deploy/electron/README.md`](deploy/electron/README.md) for details.
+
 ## Docker / FabLab Server (Recommended)
 
 The Docker image contains a static SketchForge build served by Nginx. Projects stay in each user's browser; STL and OBJ files download through that browser. The container does not receive or store project files.

--- a/deploy/electron/README.md
+++ b/deploy/electron/README.md
@@ -1,0 +1,22 @@
+# SketchForge Desktop (Electron)
+
+Wraps the static SketchForge build in an Electron shell so it can ship as a
+native desktop app on Windows, macOS, and Linux.
+
+## Run from source
+
+```bash
+npm install
+npm run electron:dev
+```
+
+## Package installers
+
+```bash
+npm run electron:dist          # current platform
+npm run electron:dist:win      # Windows NSIS installer
+npm run electron:dist:mac      # macOS DMG (universal arches)
+npm run electron:dist:linux    # Linux AppImage
+```
+
+Output goes to `deploy/electron/dist/`.

--- a/deploy/electron/electron-builder.yml
+++ b/deploy/electron/electron-builder.yml
@@ -1,0 +1,43 @@
+appId: com.formsmith.sketchforge
+productName: SketchForge
+copyright: Copyright (c) Formsmith
+directories:
+  output: deploy/electron/dist
+  buildResources: deploy/electron
+files:
+  - "package.json"
+  - "deploy/electron/main.js"
+  - "apps/web/out/**/*"
+  - "!**/node_modules/**/{CHANGELOG.md,README.md,README,readme.md,readme}"
+  - "!**/node_modules/**/{test,__tests__,tests,powered-test,example,examples}"
+  - "!**/node_modules/**/*.d.ts"
+  - "!**/node_modules/**/.bin"
+asar: true
+asarUnpack: []
+win:
+  target:
+    - target: nsis
+      arch:
+        - x64
+  artifactName: SketchForge-${version}-${os}-${arch}.${ext}
+nsis:
+  oneClick: false
+  perMachine: false
+  allowToChangeInstallationDirectory: true
+  artifactName: SketchForge-Setup-${version}.${ext}
+  shortcutName: SketchForge
+mac:
+  target:
+    - target: dmg
+      arch:
+        - x64
+        - arm64
+  category: public.app-category.graphics-design
+  artifactName: SketchForge-${version}-${os}-${arch}.${ext}
+linux:
+  target:
+    - target: AppImage
+      arch:
+        - x64
+  category: Graphics
+  artifactName: SketchForge-${version}-${os}-${arch}.${ext}

--- a/deploy/electron/main.js
+++ b/deploy/electron/main.js
@@ -1,0 +1,104 @@
+const { app, BrowserWindow, shell, Menu } = require("electron");
+const path = require("node:path");
+const fs = require("node:fs");
+
+const staticRoot = path.join(__dirname, "..", "..", "apps", "web", "out");
+const indexPath = path.join(staticRoot, "index.html");
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1400,
+    height: 900,
+    minWidth: 960,
+    minHeight: 600,
+    backgroundColor: "#0b1220",
+    title: "SketchForge",
+    icon: resolveIcon(),
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      spellcheck: false,
+    },
+  });
+
+  win.removeMenu();
+
+  if (!fs.existsSync(indexPath)) {
+    win.loadURL(
+      "data:text/html;charset=utf-8," +
+        encodeURIComponent(missingBuildHtml(indexPath)),
+    );
+  } else {
+    win.loadFile(indexPath);
+  }
+
+  win.webContents.once("did-finish-load", () => {
+    console.log("[sketchforge] did-finish-load");
+    if (process.env.SKETCHFORGE_ELECTRON_SMOKE === "1") {
+      setTimeout(() => app.quit(), 250);
+    }
+  });
+  win.webContents.on("render-process-gone", (_event, details) => {
+    if (details.reason !== "clean-exit") {
+      console.error("[sketchforge] renderer gone:", details);
+    }
+  });
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (/^https?:\/\//i.test(url)) {
+      shell.openExternal(url);
+    }
+    return { action: "deny" };
+  });
+
+  win.webContents.on("will-navigate", (event, url) => {
+    const target = new URL(url);
+    if (target.protocol !== "file:") {
+      event.preventDefault();
+      if (target.protocol === "http:" || target.protocol === "https:") {
+        shell.openExternal(url);
+      }
+    }
+  });
+}
+
+function resolveIcon() {
+  const candidates = [
+    path.join(__dirname, "icon.png"),
+    path.join(staticRoot, "assets", "sketchforge", "sketchforge-logo.png"),
+    path.join(
+      __dirname,
+      "..",
+      "..",
+      "apps",
+      "web",
+      "public",
+      "assets",
+      "sketchforge",
+      "sketchforge-logo.png",
+    ),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function missingBuildHtml(expectedPath) {
+  return `<!doctype html><meta charset="utf-8"><title>SketchForge - build missing</title>
+<style>body{font-family:system-ui,sans-serif;background:#0b1220;color:#e2e8f0;padding:32px;line-height:1.5}code{background:#1e293b;padding:2px 6px;border-radius:4px}</style>
+<h1>SketchForge static build not found</h1>
+<p>Expected file: <code>${expectedPath.replace(/&/g, "&amp;").replace(/</g, "&lt;")}</code></p>
+<p>Run <code>npm run export</code> first to generate the static export, then relaunch.</p>`;
+}
+
+app.whenReady().then(() => {
+  Menu.setApplicationMenu(null);
+  createWindow();
+
+  app.on("activate", () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") app.quit();
+});

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "sketchforge",
   "version": "0.2.0",
   "private": true,
+  "main": "deploy/electron/main.js",
   "scripts": {
     "dev": "next dev apps/web",
     "build": "next build apps/web",
-    "export": "set STATIC_EXPORT=true&& next build apps/web",
+    "export": "cross-env STATIC_EXPORT=true next build apps/web",
     "start": "next start apps/web",
     "typecheck": "tsc -p apps/web/tsconfig.json --noEmit",
     "test": "vitest run --config tests/vitest.config.ts",
@@ -15,7 +16,13 @@
     "docker:build": "docker build -f deploy/docker/Dockerfile -t sketchforge:local .",
     "docker:run": "docker run --rm -p 3000:80 sketchforge:local",
     "docker:up": "docker compose -f deploy/docker/compose.yaml up --build -d",
-    "docker:down": "docker compose -f deploy/docker/compose.yaml down"
+    "docker:down": "docker compose -f deploy/docker/compose.yaml down",
+    "electron": "electron .",
+    "electron:dev": "npm run export && electron .",
+    "electron:dist": "npm run export && electron-builder --config deploy/electron/electron-builder.yml",
+    "electron:dist:win": "npm run export && electron-builder --config deploy/electron/electron-builder.yml --win",
+    "electron:dist:mac": "npm run export && electron-builder --config deploy/electron/electron-builder.yml --mac",
+    "electron:dist:linux": "npm run export && electron-builder --config deploy/electron/electron-builder.yml --linux"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.8",
@@ -35,6 +42,9 @@
     "@types/node": "^22.15.18",
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.5",
+    "cross-env": "^7.0.3",
+    "electron": "^42.5.0",
+    "electron-builder": "^26.15.3",
     "typescript": "^5.8.3",
     "vitest": "^4.1.8"
   }


### PR DESCRIPTION
- SketchForge can ship as a native desktop app
- Switches the export script to cross-env so it runs on non-Windows hosts.

## Summary

- 

## Testing

- [x] `npm run typecheck`
- [ ] Manually tested the affected workflow

## Notes

- 
