### PR TITLE
[feature] Provide pre-built docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,50 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches:
+      - main
+      - '**'
+
+jobs:
+  build:
+    permissions:
+      packages: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ docker compose -f deploy/docker/compose-ghcr.yaml up -d
 #### Standalone (Prebuilt)
 
 ```bash
-docker run -d --name sketchforge --restart unless-stopped -p 3000:80 ghcr.io/Formsmith746/sketchforge-3d:latest
+docker run -d --name sketchforge --restart unless-stopped -p 3000:80 ghcr.io/formsmith746/sketchforge-3d:latest
 ```
 
 After running, open this on the same computer:

--- a/README.md
+++ b/README.md
@@ -92,13 +92,23 @@ If `docker` is not recognized, install Docker Desktop and open it once before ru
 
 ### Start SketchForge
 
+#### Compose (Build images locally)
+
 From the SketchForge project folder, run:
 
 ```bash
 docker compose -f deploy/docker/compose.yaml up --build -d
 ```
 
-The first start can take a few minutes because Docker builds the app. After it finishes, open this on the same computer:
+The first start can take a few minutes because Docker builds the app.
+
+#### Standalone (Prebuilt)
+
+```bash
+docker run -d --name sketchforge --restart unless-stopped -p 3000:80 ghcr.io/Formsmith746/sketchforge-3d:latest
+```
+
+After running, open this on the same computer:
 
 ```text
 http://127.0.0.1:3000/

--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ docker compose -f deploy/docker/compose.yaml up --build -d
 
 The first start can take a few minutes because Docker builds the app.
 
+#### Compose (Prebuilt)
+
+From the SketchForge project folder or with the downloaded `deploy/docker/compose-ghcr.yaml`, run:
+
+```bash
+docker compose -f deploy/docker/compose-ghcr.yaml up -d
+```
+
 #### Standalone (Prebuilt)
 
 ```bash

--- a/deploy/docker/compose-ghcr.yaml
+++ b/deploy/docker/compose-ghcr.yaml
@@ -1,6 +1,6 @@
 services:
   sketchforge:
-    image: ghcr.io/Formsmith746/sketchforge-3d:latest
+    image: ghcr.io/formsmith746/sketchforge-3d:latest
     ports:
       - "${SKETCHFORGE_PORT:-3000}:80"
     restart: unless-stopped

--- a/deploy/docker/compose-ghcr.yaml
+++ b/deploy/docker/compose-ghcr.yaml
@@ -1,0 +1,6 @@
+services:
+  sketchforge:
+    image: ghcr.io/Formsmith746/sketchforge-3d:latest
+    ports:
+      - "${SKETCHFORGE_PORT:-3000}:80"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

Provides pre-built docker images for people who want to just use it via `docker run` or a compose file without building the app every time.

This is a bit slow as it's using QEMU to build the linux/arm64 variant, but the tradeoff is that it's much less complex than using native arm64 runners.

## Testing

- [x] `npm run typecheck`
- [x] Manually tested the affected workflow

## Notes

The above testing steps don't necessarily apply because this builds Docker images, but they passed anyway and the images work as expected. You can test them using the image `ghcr.io/tystuyfzand/sketchforge-3d:feature-prebuilt-docker`

The README is also a bit rough, but highlights that it can be used with either type (local build or pre-built)