### PR TITLE
Add dark mode UI

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -23,6 +23,26 @@
   --editor-toolbar-tools-height: 76px;
 }
 
+:root[data-theme="dark"] {
+  --background: #111316;
+  --foreground: #d7e3ec;
+  --topbar: #181c21;
+  --subbar: #1f242b;
+  --panel: #15191e;
+  --tile: #1d2229;
+  --tile-hover: #252b33;
+  --border: #303842;
+  --border-strong: #43505c;
+  --muted: #758596;
+  --muted-strong: #9fb1c2;
+  --primary: #35b9e8;
+  --active-tab: #247ea7;
+  --nav-text: #d7e3ec;
+  --workplane: #3f9fba;
+  --workplane-soft: rgba(63, 159, 186, 0.16);
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.36);
+}
+
 * {
   box-sizing: border-box;
 }
@@ -71,7 +91,7 @@ button {
   top: 0;
   z-index: 8;
   display: grid;
-  grid-template-columns: minmax(210px, 280px) minmax(180px, 1fr) auto;
+  grid-template-columns: minmax(210px, 280px) minmax(180px, 1fr) auto auto;
   gap: 18px;
   align-items: center;
   min-height: 64px;
@@ -126,6 +146,30 @@ button {
   color: #243d56;
   background: transparent;
   font-size: 14px;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  min-width: 0;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 0 13px;
+  color: #40586f;
+  background: #ffffff;
+  border: 1px solid #d6e0e8;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.theme-toggle:hover {
+  color: #0a6f9b;
+  background: #e8f6fc;
+  border-color: #abd7e7;
 }
 
 .dashboard-primary,
@@ -829,7 +873,7 @@ button {
 
 @media (max-width: 860px) {
   .dashboard-topbar {
-    grid-template-columns: 1fr auto;
+    grid-template-columns: 1fr auto auto;
   }
 
   .dashboard-search {
@@ -4754,5 +4798,401 @@ button {
   .color-grid button {
     width: 24px;
     height: 24px;
+  }
+}
+
+:root[data-theme="dark"] body,
+:root[data-theme="dark"] .dashboard-shell,
+:root[data-theme="dark"] .sketchforge-editor,
+:root[data-theme="dark"] .editor-body,
+:root[data-theme="dark"] .workplane-stage {
+  background: #111316;
+  color: #d7e3ec;
+}
+
+:root[data-theme="dark"] input,
+:root[data-theme="dark"] select,
+:root[data-theme="dark"] textarea {
+  color-scheme: dark;
+}
+
+:root[data-theme="dark"] input::placeholder {
+  color: #748596;
+}
+
+:root[data-theme="dark"] .dashboard-topbar {
+  background: rgba(20, 23, 27, 0.97);
+  border-bottom-color: #2c343d;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04), 0 8px 24px rgba(0, 0, 0, 0.28);
+}
+
+:root[data-theme="dark"] .dashboard-brand,
+:root[data-theme="dark"] .dashboard-section-header h1,
+:root[data-theme="dark"] .dashboard-coming-soon,
+:root[data-theme="dark"] .project-card-title,
+:root[data-theme="dark"] .project-card-open,
+:root[data-theme="dark"] .dashboard-confirm-dialog header strong,
+:root[data-theme="dark"] .dashboard-confirm-dialog p span,
+:root[data-theme="dark"] .dashboard-rename-dialog input,
+:root[data-theme="dark"] .dashboard-setting-row input,
+:root[data-theme="dark"] .dashboard-setting-row select {
+  color: #e4edf4;
+}
+
+:root[data-theme="dark"] .dashboard-search,
+:root[data-theme="dark"] .dashboard-select,
+:root[data-theme="dark"] .dashboard-segmented,
+:root[data-theme="dark"] .theme-toggle,
+:root[data-theme="dark"] .dashboard-setting-row input,
+:root[data-theme="dark"] .dashboard-setting-row select {
+  color: #c8d6e1;
+  background: #1b2026;
+  border-color: #303943;
+}
+
+:root[data-theme="dark"] .dashboard-search input,
+:root[data-theme="dark"] .dashboard-select select {
+  color: #e4edf4;
+}
+
+:root[data-theme="dark"] .theme-toggle:hover,
+:root[data-theme="dark"] .dashboard-nav-item:hover,
+:root[data-theme="dark"] .dashboard-nav-item.active,
+:root[data-theme="dark"] .dashboard-segmented button.active {
+  color: #d9f6ff;
+  background: #173240;
+}
+
+:root[data-theme="dark"] .dashboard-sidebar,
+:root[data-theme="dark"] .dashboard-settings-panel,
+:root[data-theme="dark"] .dashboard-confirm-dialog,
+:root[data-theme="dark"] .project-card,
+:root[data-theme="dark"] .dashboard-action-tile,
+:root[data-theme="dark"] .project-card-menu {
+  color: #d7e3ec;
+  background: #181c21;
+  border-color: #303943;
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.24);
+}
+
+:root[data-theme="dark"] .dashboard-sidebar {
+  box-shadow: none;
+}
+
+:root[data-theme="dark"] .dashboard-nav-item,
+:root[data-theme="dark"] .dashboard-settings-button,
+:root[data-theme="dark"] .dashboard-section-header span,
+:root[data-theme="dark"] .project-card-meta,
+:root[data-theme="dark"] .dashboard-import-notice,
+:root[data-theme="dark"] .dashboard-confirm-dialog p,
+:root[data-theme="dark"] .dashboard-rename-dialog > label,
+:root[data-theme="dark"] .dashboard-setting-row {
+  color: #a7b7c7;
+}
+
+:root[data-theme="dark"] .dashboard-action-tile:hover,
+:root[data-theme="dark"] .project-card:hover,
+:root[data-theme="dark"] .project-menu-trigger:hover,
+:root[data-theme="dark"] .project-menu-trigger[aria-expanded="true"],
+:root[data-theme="dark"] .project-card-menu button:hover,
+:root[data-theme="dark"] .project-card-menu button:focus-visible,
+:root[data-theme="dark"] .dashboard-settings-panel header button:hover,
+:root[data-theme="dark"] .dashboard-confirm-cancel:hover {
+  background: #20262d;
+  border-color: #43505c;
+}
+
+:root[data-theme="dark"] .dashboard-action-tile.create {
+  background: #122630;
+  border-color: #247ea7;
+}
+
+:root[data-theme="dark"] .dashboard-action-tile:not(.create) .dashboard-action-icon,
+:root[data-theme="dark"] .project-menu-trigger,
+:root[data-theme="dark"] .dashboard-settings-panel header button,
+:root[data-theme="dark"] .dashboard-confirm-cancel,
+:root[data-theme="dark"] .dashboard-rename-dialog input,
+:root[data-theme="dark"] .dashboard-setting-row input,
+:root[data-theme="dark"] .dashboard-setting-row select {
+  color: #d7e3ec;
+  background: #20262d;
+  border-color: #3a4652;
+}
+
+:root[data-theme="dark"] .dashboard-confirm-overlay {
+  background: rgba(4, 7, 10, 0.58);
+}
+
+:root[data-theme="dark"] .project-thumbnail-empty {
+  color: #9fb1c2;
+  background: #15191e;
+  border-color: #303943;
+  background-image:
+    linear-gradient(45deg, rgba(78, 95, 108, 0.28) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(78, 95, 108, 0.28) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(78, 95, 108, 0.28) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(78, 95, 108, 0.28) 75%);
+}
+
+:root[data-theme="dark"] .secondary-toolbar,
+:root[data-theme="dark"] .toolbar-mode-content,
+:root[data-theme="dark"] .sketch-toolbar-ribbon {
+  background: #181c21;
+  border-color: #303943;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 1px 8px rgba(0, 0, 0, 0.24);
+}
+
+:root[data-theme="dark"] .toolbar-section {
+  border-color: rgba(67, 80, 92, 0.82);
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.01) 48%, rgba(0, 0, 0, 0.12));
+}
+
+:root[data-theme="dark"] .editor-nav-group,
+:root[data-theme="dark"] .toolbar-workspace-tabs,
+:root[data-theme="dark"] .toolbar-actions-section,
+:root[data-theme="dark"] .toolbar-left-tools,
+:root[data-theme="dark"] .toolbar-right-tools {
+  border-color: #303943;
+}
+
+:root[data-theme="dark"] .mode-tabs button,
+:root[data-theme="dark"] .toolbar-workspace-tabs button,
+:root[data-theme="dark"] .toolbar-section-label,
+:root[data-theme="dark"] .toolbar-icon,
+:root[data-theme="dark"] .shape-menu-trigger,
+:root[data-theme="dark"] .action-buttons button {
+  color: #9fb1c2;
+}
+
+:root[data-theme="dark"] .mode-tabs button:hover,
+:root[data-theme="dark"] .toolbar-workspace-tabs button:hover,
+:root[data-theme="dark"] .toolbar-icon:not(.disabled):hover,
+:root[data-theme="dark"] .toolbar-icon.active,
+:root[data-theme="dark"] .shape-menu-trigger:hover,
+:root[data-theme="dark"] .shape-menu-trigger.active,
+:root[data-theme="dark"] .action-buttons button:hover,
+:root[data-theme="dark"] .toolbar-workspace-tabs button.active {
+  color: #d9f6ff;
+  background: rgba(53, 185, 232, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(78, 194, 232, 0.28);
+}
+
+:root[data-theme="dark"] .toolbar-icon.disabled,
+:root[data-theme="dark"] .toolbar-icon:disabled,
+:root[data-theme="dark"] .sketch-command-button:disabled {
+  color: #4e5c68;
+}
+
+:root[data-theme="dark"] .shape-menu,
+:root[data-theme="dark"] .top-action-panel,
+:root[data-theme="dark"] .floating-menu,
+:root[data-theme="dark"] .editor-toast,
+:root[data-theme="dark"] .edge-modifier-panel,
+:root[data-theme="dark"] .snap-menu,
+:root[data-theme="dark"] .shape-floating-controls {
+  color: #d7e3ec;
+  background: rgba(24, 28, 33, 0.98);
+  border-color: #303943;
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.34);
+}
+
+:root[data-theme="dark"] .shape-menu header,
+:root[data-theme="dark"] .top-action-panel header,
+:root[data-theme="dark"] .edge-modifier-panel header,
+:root[data-theme="dark"] .shape-inspector-header,
+:root[data-theme="dark"] .workspace-modal-header {
+  background: rgba(28, 33, 39, 0.98);
+  border-color: #303943;
+}
+
+:root[data-theme="dark"] .shape-menu-item,
+:root[data-theme="dark"] .top-action-body button,
+:root[data-theme="dark"] .snap-menu button,
+:root[data-theme="dark"] .sketch-command-button,
+:root[data-theme="dark"] .shape-inspector .edit-sketch-button,
+:root[data-theme="dark"] .shape-inspector .inspector-action-button,
+:root[data-theme="dark"] .edge-modifier-panel button,
+:root[data-theme="dark"] .workspace-modal-footer button,
+:root[data-theme="dark"] .workspace-select select,
+:root[data-theme="dark"] .workspace-dimensions input {
+  color: #d7e3ec;
+  background: #20262d;
+  border-color: #3a4652;
+}
+
+:root[data-theme="dark"] .shape-menu-item:hover,
+:root[data-theme="dark"] .top-action-body button:hover,
+:root[data-theme="dark"] .top-action-panel header button:hover,
+:root[data-theme="dark"] .snap-menu button:hover,
+:root[data-theme="dark"] .snap-menu .selected,
+:root[data-theme="dark"] .shape-inspector .edit-sketch-button:hover:not(:disabled),
+:root[data-theme="dark"] .shape-inspector .inspector-action-button:hover:not(:disabled),
+:root[data-theme="dark"] .workspace-modal-header button:hover,
+:root[data-theme="dark"] .workspace-modal-footer button:hover {
+  color: #d9f6ff;
+  background: #173240;
+  border-color: #247ea7;
+}
+
+:root[data-theme="dark"] .top-action-body p,
+:root[data-theme="dark"] .top-action-body .import-drop-zone span,
+:root[data-theme="dark"] .export-step-note,
+:root[data-theme="dark"] .edge-modifier-panel small,
+:root[data-theme="dark"] .edge-modifier-panel label,
+:root[data-theme="dark"] .workspace-section-heading span,
+:root[data-theme="dark"] .workspace-range small,
+:root[data-theme="dark"] .workspace-dimensions label {
+  color: #9fb1c2;
+}
+
+:root[data-theme="dark"] .top-action-body .import-drop-zone {
+  color: #d7e3ec;
+  background: linear-gradient(180deg, rgba(32, 38, 45, 0.92), rgba(24, 28, 33, 0.96));
+  border-color: rgba(78, 194, 232, 0.5);
+}
+
+:root[data-theme="dark"] .shape-inspector,
+:root[data-theme="dark"] .workspace-modal-card,
+:root[data-theme="dark"] .workspace-settings-nav,
+:root[data-theme="dark"] .workspace-modal-body,
+:root[data-theme="dark"] .workspace-modal-footer {
+  color: #d7e3ec;
+  background: #181c21;
+  border-color: #303943;
+}
+
+:root[data-theme="dark"] .shape-inspector {
+  box-shadow: -3px 0 20px rgba(0, 0, 0, 0.28);
+}
+
+:root[data-theme="dark"] .property-card,
+:root[data-theme="dark"] .color-card,
+:root[data-theme="dark"] .sketch-image-preview-card,
+:root[data-theme="dark"] .workspace-row,
+:root[data-theme="dark"] .workspace-select,
+:root[data-theme="dark"] .workspace-toggle,
+:root[data-theme="dark"] .workspace-range,
+:root[data-theme="dark"] .custom-color,
+:root[data-theme="dark"] .dimension-input,
+:root[data-theme="dark"] .dimension-label {
+  color: #d7e3ec;
+  background: rgba(32, 38, 45, 0.96);
+  border-color: #3a4652;
+}
+
+:root[data-theme="dark"] .property-card-header,
+:root[data-theme="dark"] .color-card-header,
+:root[data-theme="dark"] .workspace-section-heading strong,
+:root[data-theme="dark"] .shape-inspector-header strong,
+:root[data-theme="dark"] .property-card-header:hover,
+:root[data-theme="dark"] .color-value,
+:root[data-theme="dark"] .measurement-value,
+:root[data-theme="dark"] .snap-row,
+:root[data-theme="dark"] .snap-select {
+  color: #d7e3ec;
+}
+
+:root[data-theme="dark"] .property-input,
+:root[data-theme="dark"] .property-card input,
+:root[data-theme="dark"] .sketch-image-number-input,
+:root[data-theme="dark"] .sketch-image-position-field input {
+  color: #e4edf4;
+  background: #11161b;
+  border-color: #3a4652;
+}
+
+:root[data-theme="dark"] .workspace-modal-backdrop {
+  background: rgba(4, 7, 10, 0.58);
+}
+
+:root[data-theme="dark"] .workplane-plane,
+:root[data-theme="dark"] .sketch-workspace-stage {
+  background: #11161b;
+}
+
+:root[data-theme="dark"] .sketch-plate-background {
+  fill: #1a252d;
+}
+
+:root[data-theme="dark"] .sketch-plate-border {
+  stroke: #3f9fba;
+}
+
+:root[data-theme="dark"] .sketch-grid .minor {
+  stroke: rgba(91, 151, 170, 0.34);
+}
+
+:root[data-theme="dark"] .sketch-grid .major {
+  stroke: rgba(91, 184, 210, 0.48);
+}
+
+:root[data-theme="dark"] .sketch-grid .axis {
+  stroke: rgba(74, 205, 238, 0.72);
+}
+
+:root[data-theme="dark"] .sketch-reference-shapes rect,
+:root[data-theme="dark"] .sketch-reference-shapes ellipse,
+:root[data-theme="dark"] .sketch-reference-shapes .sketch-reference-mesh-face {
+  fill: rgba(94, 122, 140, 0.2);
+  stroke: rgba(136, 167, 184, 0.52);
+}
+
+:root[data-theme="dark"] .sketch-reference-images image {
+  opacity: 0.72;
+}
+
+:root[data-theme="dark"] .sketch-point-actions,
+:root[data-theme="dark"] .sketch-grid-settings,
+:root[data-theme="dark"] .sketch-measurement-pill rect,
+:root[data-theme="dark"] .sketch-segment-dimensions rect,
+:root[data-theme="dark"] .sketch-image-dimension rect {
+  fill: #20262d;
+  background: rgba(24, 28, 33, 0.96);
+  border-color: #3a4652;
+}
+
+:root[data-theme="dark"] .sketch-measurement-pill text,
+:root[data-theme="dark"] .sketch-segment-dimensions text,
+:root[data-theme="dark"] .sketch-image-dimension text {
+  fill: #d7e3ec;
+}
+
+:root[data-theme="dark"] .cube-face,
+:root[data-theme="dark"] .camera-controls button,
+:root[data-theme="dark"] .view-control-button,
+:root[data-theme="dark"] .transform-overlay button,
+:root[data-theme="dark"] .ruler-overlay button {
+  color: #c8d6e1;
+  background: rgba(32, 38, 45, 0.9);
+  border-color: #3a4652;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.26);
+}
+
+:root[data-theme="dark"] .cube-face:hover,
+:root[data-theme="dark"] .camera-controls button:hover,
+:root[data-theme="dark"] .camera-controls button.active,
+:root[data-theme="dark"] .camera-controls button[aria-pressed="true"] {
+  color: #d9f6ff;
+  background: #173240;
+  border-color: #247ea7;
+}
+
+:root[data-theme="dark"] .selection-marquee {
+  background: rgba(53, 185, 232, 0.14);
+  border-color: rgba(53, 185, 232, 0.8);
+}
+
+:root[data-theme="dark"] * {
+  scrollbar-color: #566575 #15191e;
+}
+
+@media (max-width: 640px) {
+  .theme-toggle {
+    width: 40px;
+    padding: 0;
+  }
+
+  .theme-toggle span {
+    display: none;
   }
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Clock3, EllipsisVertical, FileUp, Grid3X3, HomeIcon, List, Pencil, Plus, Search, Settings, SlidersHorizontal, Trash2, X } from "lucide-react";
+import { Clock3, EllipsisVertical, FileUp, Grid3X3, HomeIcon, List, Moon, Pencil, Plus, Search, Settings, SlidersHorizontal, Sun, Trash2, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SketchForgeEditor, importedShapeFromStl } from "@/components/SketchForgeEditor";
 import { createLocalId } from "@/lib/localIds";
@@ -12,6 +12,7 @@ type AppView = "dashboard" | "editor";
 type ViewMode = "grid" | "list";
 type DashboardSection = "home" | "challenges";
 type DownloadMode = "browser" | "folder";
+type ColorTheme = "light" | "dark";
 
 type DashboardProject = {
   id: string;
@@ -46,6 +47,7 @@ const PROJECT_SHAPES_DB_NAME = "sketchForge.projectShapes";
 const PROJECT_SHAPES_STORE_NAME = "projectShapes";
 const DOWNLOAD_MODE_STORAGE_KEY = "sketchForge.downloadMode";
 const DOWNLOAD_FOLDER_STORAGE_KEY = "sketchForge.downloadFolder";
+const THEME_STORAGE_KEY = "sketchForge.theme";
 const PROJECT_ACCENTS: DashboardProject["accent"][] = ["cyan", "green", "gold", "red"];
 const STATIC_EXPORT_BUILD = process.env.NEXT_PUBLIC_STATIC_EXPORT === "true";
 
@@ -239,8 +241,16 @@ function projectNameFromFileName(fileName: string) {
   return fileName.replace(/\.[^.]+$/, "").trim() || "Imported STL design";
 }
 
+function storedColorTheme(): ColorTheme {
+  if (typeof window === "undefined") return "light";
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored === "dark" || stored === "light") return stored;
+  return window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
 export default function Home() {
   const [mounted, setMounted] = useState(false);
+  const [theme, setTheme] = useState<ColorTheme>("light");
   const [view, setView] = useState<AppView>("dashboard");
   const [editorStarted, setEditorStarted] = useState(false);
   const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
@@ -260,6 +270,11 @@ export default function Home() {
   const projectShapeSaveQueuesRef = useRef<Record<string, Promise<void>>>({});
 
   useEffect(() => {
+    const nextTheme = storedColorTheme();
+    setTheme(nextTheme);
+    document.documentElement.dataset.theme = nextTheme;
+    document.documentElement.style.colorScheme = nextTheme;
+
     const { projects: storedProjects, legacyShapes } = readStoredProjects();
     setProjects(storedProjects);
     if (Object.keys(legacyShapes).length > 0) {
@@ -284,6 +299,14 @@ export default function Home() {
     }
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.style.colorScheme = theme;
+    if (mounted) {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    }
+  }, [mounted, theme]);
 
   useEffect(() => {
     if (!mounted) return;
@@ -592,6 +615,7 @@ export default function Home() {
   const activeProject = activeProjectId ? projects.find((project) => project.id === activeProjectId) ?? null : null;
   const activeProjectShapeEntry = activeProjectId ? projectShapesById[activeProjectId] : null;
   const canRenderEditor = !activeProjectId || (Boolean(activeProject) && Boolean(activeProjectShapeEntry));
+  const toggleTheme = () => setTheme((current) => (current === "dark" ? "light" : "dark"));
   const projectDebugSummary = projects.map((project) => ({
     id: project.id,
     revision: project.revision,
@@ -631,6 +655,7 @@ export default function Home() {
           settingsOpen={settingsOpen}
           staticExportBuild={STATIC_EXPORT_BUILD}
           sortMode={sortMode}
+          theme={theme}
           viewMode={viewMode}
           onCloseSettings={() => setSettingsOpen(false)}
           onCreate={() => createAndOpenProject()}
@@ -648,6 +673,7 @@ export default function Home() {
           onQueryChange={setQuery}
           onRenameProject={renameProject}
           onSortModeChange={setSortMode}
+          onToggleTheme={toggleTheme}
           onViewModeChange={setViewMode}
           onWorkspace={openLatestProject}
         />
@@ -665,6 +691,8 @@ export default function Home() {
             projectId={activeProjectId}
             projectName={activeProject?.name}
             projectRevision={activeProjectShapeEntry?.revision ?? activeProject?.revision ?? 0}
+            theme={theme}
+            onToggleTheme={toggleTheme}
           />
         </div>
       ) : null}
@@ -682,6 +710,7 @@ function Dashboard({
   settingsOpen,
   staticExportBuild,
   sortMode,
+  theme,
   viewMode,
   onCloseSettings,
   onCreate,
@@ -696,6 +725,7 @@ function Dashboard({
   onQueryChange,
   onRenameProject,
   onSortModeChange,
+  onToggleTheme,
   onViewModeChange,
   onWorkspace,
 }: {
@@ -708,6 +738,7 @@ function Dashboard({
   settingsOpen: boolean;
   staticExportBuild: boolean;
   sortMode: string;
+  theme: ColorTheme;
   viewMode: ViewMode;
   onCloseSettings: () => void;
   onCreate: () => void;
@@ -722,6 +753,7 @@ function Dashboard({
   onQueryChange: (value: string) => void;
   onRenameProject: (projectId: string, name: string) => void;
   onSortModeChange: (value: string) => void;
+  onToggleTheme: () => void;
   onViewModeChange: (value: ViewMode) => void;
   onWorkspace: () => void;
 }) {
@@ -772,6 +804,10 @@ function Dashboard({
           <Search size={18} strokeWidth={2.4} />
           <input value={query} onChange={(event) => onQueryChange(event.currentTarget.value)} placeholder="Search projects" aria-label="Search projects" />
         </div>
+        <button className="theme-toggle" type="button" aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`} title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`} onClick={onToggleTheme}>
+          {theme === "dark" ? <Sun size={18} strokeWidth={2.4} /> : <Moon size={18} strokeWidth={2.4} />}
+          <span>{theme === "dark" ? "Light" : "Dark"}</span>
+        </button>
         <button className="dashboard-primary" type="button" onClick={onCreate}>
           <Plus size={20} strokeWidth={2.6} />
           <span>Create</span>

--- a/apps/web/src/components/SketchForgeEditor.tsx
+++ b/apps/web/src/components/SketchForgeEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Download, X } from "lucide-react";
+import { Check, Download, Moon, Sun, X } from "lucide-react";
 import type manifoldModule from "manifold-3d";
 import type { ManifoldToplevel } from "manifold-3d";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -84,6 +84,7 @@ export { importedShapeFromStl };
 type TopPanel = "import" | "export" | "tips" | "profile" | "settings" | null;
 type ExportFormat = "stl" | "obj";
 type ToolbarMode = "geometry" | "sketch";
+type ColorTheme = "light" | "dark";
 type Vec3 = [number, number, number];
 type MeshData = { name: string; vertices: Vec3[]; faces: [number, number, number][] };
 type Cuboid = { minX: number; maxX: number; minY: number; maxY: number; minZ: number; maxZ: number };
@@ -5103,6 +5104,8 @@ export function SketchForgeEditor({
   projectId,
   projectName = "SketchForge design",
   projectRevision = 0,
+  theme = "light",
+  onToggleTheme,
 }: {
   initialShapes?: WorkplaneShape[];
   initialSnap?: GridSize;
@@ -5114,6 +5117,8 @@ export function SketchForgeEditor({
   projectId?: string | null;
   projectName?: string;
   projectRevision?: number;
+  theme?: ColorTheme;
+  onToggleTheme?: () => void;
 } = {}) {
   const [shapes, setShapes] = useState<WorkplaneShape[]>(() => initialShapes.map(canonicalizeShape));
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -7819,6 +7824,7 @@ export function SketchForgeEditor({
     <div className="sketchforge-editor">
       <SecondaryToolbar
         toolbarMode={toolbarMode}
+        theme={theme}
         onToolbarModeChange={(mode) => {
           setToolbarMode(mode);
           setTopPanel(null);
@@ -7882,6 +7888,7 @@ export function SketchForgeEditor({
           setTopPanel(panel);
           setMenuOpen(false);
         }}
+        onToggleTheme={onToggleTheme}
         onAddShape={(shape) => {
           addShape(shape);
           setTopPanel(null);
@@ -7942,6 +7949,7 @@ export function SketchForgeEditor({
           initialSnap={initialSnap}
           initialWorkspace={initialWorkspace}
           workspaceSettingsKey={projectId ?? "local-workplane"}
+          theme={theme}
           onAddShape={addShape}
           onAlignAnchorChange={chooseAlignAnchor}
           onAlignPreview={previewAlignSelection}
@@ -8095,6 +8103,7 @@ function SketchReferenceIcon({ name }: { name: SketchReferenceIconName }) {
 
 function SecondaryToolbar({
   toolbarMode,
+  theme,
   onToolbarModeChange,
   alignMode,
   canAlign,
@@ -8142,9 +8151,11 @@ function SecondaryToolbar({
   onWorkplaneTool,
   workplaneMode,
   onTopPanel,
+  onToggleTheme,
   onAddShape,
 }: {
   toolbarMode: ToolbarMode;
+  theme: ColorTheme;
   onToolbarModeChange: (mode: ToolbarMode) => void;
   alignMode: boolean;
   canAlign: boolean;
@@ -8192,6 +8203,7 @@ function SecondaryToolbar({
   onWorkplaneTool: () => void;
   workplaneMode: boolean;
   onTopPanel: (panel: TopPanel) => void;
+  onToggleTheme?: () => void;
   onAddShape: (shape: ShapeAsset) => void;
 }) {
   const [shapesOpen, setShapesOpen] = useState(false);
@@ -8385,6 +8397,11 @@ function SecondaryToolbar({
           <button className="action-icon-button" aria-label="Workspace settings" title="Workspace settings" onClick={() => window.dispatchEvent(new Event("sketchforge:open-workspace-settings"))}>
             <ToolbarSettingsIcon />
           </button>
+          {onToggleTheme ? (
+            <button className="action-icon-button theme-toggle-icon" aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`} title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`} onClick={onToggleTheme}>
+              {theme === "dark" ? <Sun size={20} strokeWidth={2.4} /> : <Moon size={20} strokeWidth={2.4} />}
+            </button>
+          ) : null}
         </div>
       </div>
           </>

--- a/apps/web/src/components/WorkplaneViewport.tsx
+++ b/apps/web/src/components/WorkplaneViewport.tsx
@@ -136,6 +136,7 @@ type WorkplaneViewportProps = {
   initialSnap?: GridSize;
   initialWorkspace?: WorkplaneWorkspaceSettings;
   workspaceSettingsKey?: string | null;
+  theme?: "light" | "dark";
   onAddShape: (shape: ShapeAsset, point?: { x: number; z: number; elevation?: number }) => void;
   onAlignAnchorChange: (id: string) => void;
   onAlignPreview: (axis: AlignAxis, target: AlignTarget) => void;
@@ -1150,6 +1151,7 @@ export function WorkplaneViewport({
   initialSnap,
   initialWorkspace,
   workspaceSettingsKey,
+  theme = "light",
   onAddShape,
   onAlignAnchorChange,
   onAlignPreview,
@@ -1442,7 +1444,7 @@ export function WorkplaneViewport({
 
   useEffect(() => {
     workspaceRef.current = workspace;
-    rebuildWorkplane(threeRef.current, workspace);
+    rebuildWorkplane(threeRef.current, themedWorkspace(workspace, theme));
     if (threeRef.current) {
       syncTransformOverlay(
         threeRef.current,
@@ -1456,7 +1458,7 @@ export function WorkplaneViewport({
       syncRulerOverlay(threeRef.current, rulerModelRef.current, rulerOverlayRef, setRulerOverlay, workspace.accuracy);
       threeRef.current.needsRender = true;
     }
-  }, [workspace]);
+  }, [theme, workspace]);
 
   useEffect(() => {
     setSelectionHelpersVisible(threeRef.current, activeTransformKind !== "rotate");
@@ -3203,6 +3205,13 @@ function syncViewCube(state: ThreeState, cube: HTMLDivElement | null) {
   cube.style.transform = `rotateX(${-pitch}deg) rotateY(${-yaw}deg)`;
 }
 
+function themedWorkspace(workspace: WorkspaceSettings, theme: "light" | "dark"): WorkspaceSettings {
+  if (theme !== "dark" || workspace.background.toLowerCase() !== DEFAULT_WORKSPACE.background.toLowerCase()) {
+    return workspace;
+  }
+  return { ...workspace, background: "#12161b" };
+}
+
 function rebuildWorkplane(state: ThreeState | null, workspace: WorkspaceSettings) {
   if (!state) {
     return;
@@ -3216,9 +3225,9 @@ function rebuildWorkplane(state: ThreeState | null, workspace: WorkspaceSettings
   const base = new THREE.Mesh(
     new THREE.PlaneGeometry(workspace.width, workspace.depth),
     new THREE.MeshStandardMaterial({
-      color: "#ddf8ff",
+      color: workspace.background === "#12161b" ? "#26343d" : "#ddf8ff",
       transparent: true,
-      opacity: 0.68,
+      opacity: workspace.background === "#12161b" ? 0.82 : 0.68,
       roughness: 0.92,
       side: THREE.FrontSide,
     }),


### PR DESCRIPTION
## Summary
- add persistent light/dark theme state with dashboard and editor toggles
- apply dark-mode styling across dashboard, editor toolbar, panels, modals, inspector, sketch workspace, and viewport controls
- use a dark visual workplane background when the default workspace background is active without changing saved workspace settings

## Verification
- npm run typecheck
- npm run test
- npm run build