### PR TITLE
fix: keep .skf ZIP mtime within DOS date range in all timezones

### DIFF
--- a/apps/web/src/lib/skfProject.ts
+++ b/apps/web/src/lib/skfProject.ts
@@ -602,7 +602,11 @@ function activeProjectIndexes(state: SkfStateV1) {
 
 function zipAsync(files: AsyncZippable) {
   return new Promise<Uint8Array>((resolve, reject) => {
-    zip(files, { level: 6, mtime: new Date("1980-01-01T00:00:00.000Z") }, (error, data) => {
+    // fflate encodes the ZIP entry mtime as a DOS date using local-time getters and
+    // rejects years outside 1980-2099. A UTC-pinned "1980-01-01T00:00:00Z" rolls back
+    // to 1979 in any timezone west of UTC, so build the epoch from local components to
+    // keep the year at exactly 1980 everywhere.
+    zip(files, { level: 6, mtime: new Date(1980, 0, 1) }, (error, data) => {
       if (error) reject(error);
       else resolve(data);
     });

--- a/tests/unit/skfProject.test.ts
+++ b/tests/unit/skfProject.test.ts
@@ -339,6 +339,23 @@ describe("SketchForge .skf project packages", () => {
     expect(restored.shapes[1].importedMesh?.positions).toEqual(mesh.positions);
   });
 
+  it("exports in a far-western timezone without underflowing the ZIP 1980 date floor", async () => {
+    // ZIP stores entry mtimes as DOS dates, and fflate encodes them with local-time
+    // getters, rejecting years outside 1980-2099 with "date not in range 1980-2099".
+    // A UTC-pinned epoch rolls back to 1979 west of UTC, so exercise the fix under the
+    // most extreme western offset. Node re-reads process.env.TZ per Date operation.
+    const originalTz = process.env.TZ;
+    process.env.TZ = "Etc/GMT+12";
+    try {
+      const exported = await exportSkfProject(input([shape("box")]));
+      const restored = await importSkfProject(exported);
+      expect(restored.shapes[0].kind).toBe("box");
+    } finally {
+      if (originalTz === undefined) delete process.env.TZ;
+      else process.env.TZ = originalTz;
+    }
+  });
+
   it("migrates the documented v0 JSON project without changing IDs", async () => {
     const box = shape("box", "legacy-box");
     const legacy = strToU8(JSON.stringify({


### PR DESCRIPTION
## Problem

Exporting a project to `.skf` — including **Export → SKF → Save to shared** — fails for users west of UTC with:

```
date not in range 1980-2099
```

## Root cause

`.skf` files are ZIP archives, and ZIP stores each entry's modification time as a DOS date, valid only for years **1980–2099**. The writer in `apps/web/src/lib/skfProject.ts` pinned the entry `mtime` to a UTC-based epoch:

```ts
zip(files, { level: 6, mtime: new Date("1980-01-01T00:00:00.000Z") }, ...)
```

fflate encodes ZIP mtimes into DOS dates using **local-time** getters. In any timezone west of UTC, `1980-01-01T00:00:00Z` is actually `1979-12-31` locally, so the year falls below the 1980 floor and fflate throws. Users in/east of UTC never see it, which is why it slipped through.

## Fix

Build the pinned epoch from local components so the year is always exactly 1980 in every timezone:

```ts
zip(files, { level: 6, mtime: new Date(1980, 0, 1) }, ...)
```

The timestamp stays pinned (deterministic output per machine, which the SKF content hashing relies on).

## Test

Adds a regression test that exports and round-trips a project under `TZ=Etc/GMT+12` (the most extreme western offset). It fails with the exact `date not in range 1980-2099` error on the old code and passes with the fix. Full unit suite: 125 passing.