### PR TITLE
feat(desktop): publish Windows, Linux, and macOS releases

### DIFF
--- a/.github/SETUP.md
+++ b/.github/SETUP.md
@@ -38,10 +38,10 @@ The workflow builds these packages:
 
 - Windows NSIS installer
 - Linux AppImage
-- macOS universal DMG
-- macOS universal ZIP
+- macOS x64 DMG and ZIP
+- macOS arm64 DMG and ZIP
 
-The macOS ZIP and `latest-mac.yml` file are required by `electron-updater`.
+The macOS ZIP files and merged `latest-mac.yml` file are required by `electron-updater`.
 
 ## macOS signing and notarization
 
@@ -56,15 +56,19 @@ The macOS job reads these repository secrets:
 When all signing and Apple notarization variables are present, the macOS artifacts use their normal names:
 
 ```text
-SketchForge-VERSION-universal.dmg
-SketchForge-VERSION-universal.zip
+SketchForge-VERSION-x64.dmg
+SketchForge-VERSION-x64.zip
+SketchForge-VERSION-arm64.dmg
+SketchForge-VERSION-arm64.zip
 ```
 
 When one or more signing or Apple notarization variables are missing, the workflow marks the packages as unsigned:
 
 ```text
-SketchForge-VERSION-universal-unsigned.dmg
-SketchForge-VERSION-universal-unsigned.zip
+SketchForge-VERSION-x64-unsigned.dmg
+SketchForge-VERSION-x64-unsigned.zip
+SketchForge-VERSION-arm64-unsigned.dmg
+SketchForge-VERSION-arm64-unsigned.zip
 ```
 
 Unsigned packages trigger a Gatekeeper warning. Add the signing and notarization secrets before public distribution.

--- a/.github/SETUP.md
+++ b/.github/SETUP.md
@@ -49,7 +49,7 @@ The macOS job reads these repository secrets:
 
 - `CSC_LINK`: base64-encoded Developer ID Application certificate
 - `CSC_KEY_PASSWORD`: certificate password
-- `APPLE_API_KEY`: App Store Connect API private key path
+- `APPLE_API_KEY`: App Store Connect API private key contents or base64-encoded contents
 - `APPLE_API_KEY_ID`: App Store Connect API key ID
 - `APPLE_API_ISSUER`: App Store Connect API issuer ID
 

--- a/.github/SETUP.md
+++ b/.github/SETUP.md
@@ -1,0 +1,72 @@
+# Repository and release setup
+
+## Repository owner
+
+The desktop updater publishes releases for `Formsmith746/SketchForge-3D`.
+
+Keep these values in `apps/desktop/electron-builder.yml`:
+
+```yaml
+publish:
+  provider: github
+  owner: Formsmith746
+  repo: SketchForge-3D
+```
+
+The Git remote can use another account or mirror. The `publish.owner` value must match the repository that hosts the release assets.
+
+## GitHub Actions permissions
+
+The `Desktop Release` workflow needs permission to create tags and upload release assets.
+
+Set the repository workflow permission to **Read and write permissions** under:
+
+`Settings` → `Actions` → `General` → `Workflow permissions`
+
+The workflow also declares:
+
+```yaml
+permissions:
+  contents: write
+```
+
+## Create a release
+
+Push a tag such as `v1.0.4`, or run `Desktop Release` with `workflow_dispatch` and enter `1.0.4`.
+
+The workflow builds these packages:
+
+- Windows NSIS installer
+- Linux AppImage
+- macOS universal DMG
+- macOS universal ZIP
+
+The macOS ZIP and `latest-mac.yml` file are required by `electron-updater`.
+
+## macOS signing and notarization
+
+The macOS job reads these repository secrets:
+
+- `CSC_LINK`: base64-encoded Developer ID Application certificate
+- `CSC_KEY_PASSWORD`: certificate password
+- `APPLE_API_KEY`: App Store Connect API private key path
+- `APPLE_API_KEY_ID`: App Store Connect API key ID
+- `APPLE_API_ISSUER`: App Store Connect API issuer ID
+
+When all signing and Apple notarization variables are present, the macOS artifacts use their normal names:
+
+```text
+SketchForge-VERSION-universal.dmg
+SketchForge-VERSION-universal.zip
+```
+
+When one or more signing or Apple notarization variables are missing, the workflow marks the packages as unsigned:
+
+```text
+SketchForge-VERSION-universal-unsigned.dmg
+SketchForge-VERSION-universal-unsigned.zip
+```
+
+Unsigned packages trigger a Gatekeeper warning. Add the signing and notarization secrets before public distribution.
+
+Do not commit certificates, private keys, or passwords.

--- a/.github/actions/build-linux/action.yml
+++ b/.github/actions/build-linux/action.yml
@@ -1,0 +1,35 @@
+name: Build Linux desktop
+
+description: Build and store the Linux desktop package.
+
+inputs:
+  version:
+    description: Package version.
+    required: true
+  artifact-name:
+    description: GitHub Actions artifact name.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Build Linux package
+      shell: bash
+      run: npm run desktop:dist -- --publish never --linux --x64
+
+    - name: Verify Linux artifacts
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        test -f "dist/desktop/SketchForge-$VERSION-x86_64.AppImage"
+        test -f dist/desktop/latest-linux.yml
+
+    - name: Store Linux artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: |
+          dist/desktop/SketchForge-*.AppImage
+          dist/desktop/latest-linux.yml
+        if-no-files-found: error

--- a/.github/actions/build-mac/action.yml
+++ b/.github/actions/build-mac/action.yml
@@ -42,10 +42,13 @@ runs:
         APPLE_API_ISSUER: ${{ inputs.apple-api-issuer }}
       run: |
         suffix=""
+        signing_enabled=true
         if [[ -z "$CSC_LINK" || -z "$CSC_KEY_PASSWORD" || -z "$APPLE_API_KEY" || -z "$APPLE_API_KEY_ID" || -z "$APPLE_API_ISSUER" ]]; then
           suffix="-unsigned"
+          signing_enabled=false
         fi
         echo "artifact_suffix=$suffix" >> "$GITHUB_OUTPUT"
+        echo "signing_enabled=$signing_enabled" >> "$GITHUB_OUTPUT"
 
     - name: Build macOS package
       shell: bash
@@ -55,6 +58,7 @@ runs:
         APPLE_API_KEY: ${{ inputs.apple-api-key }}
         APPLE_API_KEY_ID: ${{ inputs.apple-api-key-id }}
         APPLE_API_ISSUER: ${{ inputs.apple-api-issuer }}
+        CSC_IDENTITY_AUTO_DISCOVERY: ${{ steps.signing.outputs.signing_enabled }}
       run: |
         npm run desktop:dist -- --publish never --mac --${{ inputs.arch }} \
           "-c.mac.artifactName=\${productName}-\${version}-\${arch}${{ steps.signing.outputs.artifact_suffix }}.\${ext}"

--- a/.github/actions/build-mac/action.yml
+++ b/.github/actions/build-mac/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: Developer ID Application certificate password.
     required: false
   apple-api-key:
-    description: App Store Connect API private key path.
+    description: App Store Connect API private key contents, base64, or path.
     required: false
   apple-api-key-id:
     description: App Store Connect API key ID.
@@ -55,13 +55,31 @@ runs:
       env:
         CSC_LINK: ${{ inputs.csc-link }}
         CSC_KEY_PASSWORD: ${{ inputs.csc-key-password }}
-        APPLE_API_KEY: ${{ inputs.apple-api-key }}
+        APPLE_API_KEY_INPUT: ${{ inputs.apple-api-key }}
         APPLE_API_KEY_ID: ${{ inputs.apple-api-key-id }}
         APPLE_API_ISSUER: ${{ inputs.apple-api-issuer }}
         CSC_IDENTITY_AUTO_DISCOVERY: ${{ steps.signing.outputs.signing_enabled }}
       run: |
         if [[ "${{ steps.signing.outputs.signing_enabled }}" == "false" ]]; then
           unset CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER
+        else
+          if [[ -f "$APPLE_API_KEY_INPUT" ]]; then
+            export APPLE_API_KEY="$APPLE_API_KEY_INPUT"
+          else
+            export APPLE_API_KEY="$RUNNER_TEMP/sketchforge-notary-${{ inputs.arch }}.p8"
+            node <<'NODE'
+            const fs = require("node:fs");
+            const input = process.env.APPLE_API_KEY_INPUT || "";
+            const output = process.env.APPLE_API_KEY;
+            const decoded = input.includes("BEGIN PRIVATE KEY")
+              ? input
+              : Buffer.from(input, "base64").toString("utf8");
+            if (!decoded.includes("BEGIN PRIVATE KEY")) {
+              throw new Error("APPLE_API_KEY must be a .p8 path, key contents, or base64-encoded key contents.");
+            }
+            fs.writeFileSync(output, decoded, { mode: 0o600 });
+            NODE
+          fi
         fi
         npm run desktop:dist -- --publish never --mac --${{ inputs.arch }} \
           "-c.mac.artifactName=\${productName}-\${version}-\${arch}${{ steps.signing.outputs.artifact_suffix }}.\${ext}"
@@ -74,9 +92,14 @@ runs:
         suffix="${{ steps.signing.outputs.artifact_suffix }}"
         test -f "dist/desktop/SketchForge-$VERSION-${{ inputs.arch }}${suffix}.dmg"
         test -f "dist/desktop/SketchForge-$VERSION-${{ inputs.arch }}${suffix}.zip"
-        test -f dist/desktop/latest-mac.yml
+        if [[ "${{ steps.signing.outputs.signing_enabled }}" == "true" ]]; then
+          test -f dist/desktop/latest-mac.yml
+        else
+          rm -f dist/desktop/latest-mac.yml
+        fi
 
     - name: Rename macOS update manifest
+      if: steps.signing.outputs.signing_enabled == 'true'
       shell: bash
       run: mv dist/desktop/latest-mac.yml "dist/desktop/latest-mac-${{ inputs.arch }}.yml"
 

--- a/.github/actions/build-mac/action.yml
+++ b/.github/actions/build-mac/action.yml
@@ -60,6 +60,9 @@ runs:
         APPLE_API_ISSUER: ${{ inputs.apple-api-issuer }}
         CSC_IDENTITY_AUTO_DISCOVERY: ${{ steps.signing.outputs.signing_enabled }}
       run: |
+        if [[ "${{ steps.signing.outputs.signing_enabled }}" == "false" ]]; then
+          unset CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER
+        fi
         npm run desktop:dist -- --publish never --mac --${{ inputs.arch }} \
           "-c.mac.artifactName=\${productName}-\${version}-\${arch}${{ steps.signing.outputs.artifact_suffix }}.\${ext}"
 

--- a/.github/actions/build-mac/action.yml
+++ b/.github/actions/build-mac/action.yml
@@ -1,0 +1,77 @@
+name: Build macOS desktop
+
+description: Build and store the macOS desktop package.
+
+inputs:
+  version:
+    description: Package version.
+    required: true
+  artifact-name:
+    description: GitHub Actions artifact name.
+    required: true
+  csc-link:
+    description: Developer ID Application certificate.
+    required: false
+  csc-key-password:
+    description: Developer ID Application certificate password.
+    required: false
+  apple-api-key:
+    description: App Store Connect API private key path.
+    required: false
+  apple-api-key-id:
+    description: App Store Connect API key ID.
+    required: false
+  apple-api-issuer:
+    description: App Store Connect API issuer ID.
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve macOS signing state
+      id: signing
+      shell: bash
+      env:
+        CSC_LINK: ${{ inputs.csc-link }}
+        CSC_KEY_PASSWORD: ${{ inputs.csc-key-password }}
+        APPLE_API_KEY: ${{ inputs.apple-api-key }}
+        APPLE_API_KEY_ID: ${{ inputs.apple-api-key-id }}
+        APPLE_API_ISSUER: ${{ inputs.apple-api-issuer }}
+      run: |
+        suffix=""
+        if [[ -z "$CSC_LINK" || -z "$CSC_KEY_PASSWORD" || -z "$APPLE_API_KEY" || -z "$APPLE_API_KEY_ID" || -z "$APPLE_API_ISSUER" ]]; then
+          suffix="-unsigned"
+        fi
+        echo "artifact_suffix=$suffix" >> "$GITHUB_OUTPUT"
+
+    - name: Build macOS package
+      shell: bash
+      env:
+        CSC_LINK: ${{ inputs.csc-link }}
+        CSC_KEY_PASSWORD: ${{ inputs.csc-key-password }}
+        APPLE_API_KEY: ${{ inputs.apple-api-key }}
+        APPLE_API_KEY_ID: ${{ inputs.apple-api-key-id }}
+        APPLE_API_ISSUER: ${{ inputs.apple-api-issuer }}
+      run: |
+        npm run desktop:dist -- --publish never --mac --universal \
+          "-c.mac.artifactName=\${productName}-\${version}-\${arch}${{ steps.signing.outputs.artifact_suffix }}.\${ext}"
+
+    - name: Verify macOS artifacts
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        suffix="${{ steps.signing.outputs.artifact_suffix }}"
+        test -f "dist/desktop/SketchForge-$VERSION-universal${suffix}.dmg"
+        test -f "dist/desktop/SketchForge-$VERSION-universal${suffix}.zip"
+        test -f dist/desktop/latest-mac.yml
+
+    - name: Store macOS artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: |
+          dist/desktop/SketchForge-*-universal*.dmg
+          dist/desktop/SketchForge-*-universal*.zip
+          dist/desktop/latest-mac.yml
+        if-no-files-found: error

--- a/.github/actions/build-mac/action.yml
+++ b/.github/actions/build-mac/action.yml
@@ -9,6 +9,9 @@ inputs:
   artifact-name:
     description: GitHub Actions artifact name.
     required: true
+  arch:
+    description: macOS architecture.
+    required: true
   csc-link:
     description: Developer ID Application certificate.
     required: false
@@ -53,7 +56,7 @@ runs:
         APPLE_API_KEY_ID: ${{ inputs.apple-api-key-id }}
         APPLE_API_ISSUER: ${{ inputs.apple-api-issuer }}
       run: |
-        npm run desktop:dist -- --publish never --mac --universal \
+        npm run desktop:dist -- --publish never --mac --${{ inputs.arch }} \
           "-c.mac.artifactName=\${productName}-\${version}-\${arch}${{ steps.signing.outputs.artifact_suffix }}.\${ext}"
 
     - name: Verify macOS artifacts
@@ -62,16 +65,20 @@ runs:
         VERSION: ${{ inputs.version }}
       run: |
         suffix="${{ steps.signing.outputs.artifact_suffix }}"
-        test -f "dist/desktop/SketchForge-$VERSION-universal${suffix}.dmg"
-        test -f "dist/desktop/SketchForge-$VERSION-universal${suffix}.zip"
+        test -f "dist/desktop/SketchForge-$VERSION-${{ inputs.arch }}${suffix}.dmg"
+        test -f "dist/desktop/SketchForge-$VERSION-${{ inputs.arch }}${suffix}.zip"
         test -f dist/desktop/latest-mac.yml
+
+    - name: Rename macOS update manifest
+      shell: bash
+      run: mv dist/desktop/latest-mac.yml "dist/desktop/latest-mac-${{ inputs.arch }}.yml"
 
     - name: Store macOS artifacts
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: |
-          dist/desktop/SketchForge-*-universal*.dmg
-          dist/desktop/SketchForge-*-universal*.zip
-          dist/desktop/latest-mac.yml
+          dist/desktop/SketchForge-*-${{ inputs.arch }}*.dmg
+          dist/desktop/SketchForge-*-${{ inputs.arch }}*.zip
+          dist/desktop/latest-mac-${{ inputs.arch }}.yml
         if-no-files-found: error

--- a/.github/actions/build-win32/action.yml
+++ b/.github/actions/build-win32/action.yml
@@ -1,0 +1,44 @@
+name: Build Windows desktop
+
+description: Build and store the Windows desktop package.
+
+inputs:
+  version:
+    description: Package version.
+    required: true
+  artifact-name:
+    description: GitHub Actions artifact name.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Build Windows package
+      shell: bash
+      run: npm run desktop:dist -- --publish never --win --x64
+
+    - name: Verify Windows artifacts
+      shell: pwsh
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        $required = @(
+          "dist/desktop/SketchForge-Setup-$env:VERSION-x64.exe",
+          "dist/desktop/SketchForge-Setup-$env:VERSION-x64.exe.blockmap",
+          "dist/desktop/latest.yml"
+        )
+        foreach ($file in $required) {
+          if (-not (Test-Path $file -PathType Leaf)) {
+            throw "Missing Windows artifact: $file"
+          }
+        }
+
+    - name: Store Windows artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: |
+          dist/desktop/SketchForge-Setup-*-x64.exe
+          dist/desktop/SketchForge-Setup-*-x64.exe.blockmap
+          dist/desktop/latest.yml
+        if-no-files-found: error

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -172,7 +172,12 @@ jobs:
         run: |
           git fetch --tags --force
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "$TAG already exists."
+            tag_sha=$(git rev-list -n 1 "$TAG")
+            source_sha=$(git rev-parse "$SOURCE_SHA^{commit}")
+            if [[ "$tag_sha" != "$source_sha" ]]; then
+              echo "$TAG already points to $tag_sha instead of $source_sha." >&2
+              exit 1
+            fi
           else
             git tag "$TAG" "$SOURCE_SHA"
             git push origin "$TAG"
@@ -213,14 +218,24 @@ jobs:
             "dist/release/macos-x64/latest-mac-x64.yml",
             "dist/release/macos-arm64/latest-mac-arm64.yml",
           ];
-          const manifests = paths.map((file) => yaml.load(fs.readFileSync(file, "utf8")));
-          const merged = {
-            ...manifests[0],
-            files: manifests.flatMap((manifest) => manifest.files || []),
-          };
-          delete merged.path;
-          delete merged.sha512;
-          fs.writeFileSync("dist/release/latest-mac.yml", yaml.dump(merged, { noRefs: true }));
+          const existingPaths = paths.filter((file) => fs.existsSync(file));
+          if (existingPaths.length === 1) {
+            throw new Error("Only one macOS architecture produced an updater manifest.");
+          }
+          if (existingPaths.length === 2) {
+            const manifests = existingPaths.map((file) => yaml.load(fs.readFileSync(file, "utf8")));
+            const versions = new Set(manifests.map((manifest) => manifest.version));
+            if (versions.size !== 1) {
+              throw new Error("macOS updater manifests have different versions.");
+            }
+            const merged = {
+              ...manifests[0],
+              files: manifests.flatMap((manifest) => manifest.files || []),
+            };
+            delete merged.path;
+            delete merged.sha512;
+            fs.writeFileSync("dist/release/latest-mac.yml", yaml.dump(merged, { noRefs: true }));
+          }
           for (const directory of ["macos-x64", "macos-arm64"]) {
             for (const file of fs.readdirSync(`dist/release/${directory}`)) {
               if (file === "latest-mac-x64.yml" || file === "latest-mac-arm64.yml") continue;
@@ -254,7 +269,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
-        run: gh release upload "$TAG" dist/release/* --clobber
+        run: |
+          while IFS= read -r asset; do
+            case "$asset" in
+              SketchForge-*|latest.yml|latest-linux.yml|latest-mac.yml)
+                gh release delete-asset "$TAG" "$asset" --yes
+                ;;
+            esac
+          done < <(gh release view "$TAG" --json assets --jq '.assets[].name')
+          gh release upload "$TAG" dist/release/*
 
       - name: Verify release assets
         env:
@@ -283,13 +306,21 @@ jobs:
             "SketchForge-$VERSION-x64${suffix}.dmg" \
             "SketchForge-$VERSION-x64${suffix}.zip" \
             "SketchForge-$VERSION-arm64${suffix}.dmg" \
-            "SketchForge-$VERSION-arm64${suffix}.zip" \
-            "latest-mac.yml"; do
+            "SketchForge-$VERSION-arm64${suffix}.zip"; do
             grep -Fxq "$expected" <<< "$names" || {
               echo "GitHub release is missing $expected" >&2
               exit 1
             }
           done
+          if [[ -z "$suffix" ]]; then
+            grep -Fxq "latest-mac.yml" <<< "$names" || {
+              echo "GitHub release is missing latest-mac.yml" >&2
+              exit 1
+            }
+          elif grep -Fxq "latest-mac.yml" <<< "$names"; then
+            echo "Unsigned macOS builds must not publish latest-mac.yml" >&2
+            exit 1
+          fi
 
       - name: Publish release as latest
         env:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,4 +1,5 @@
 name: Desktop Release
+run-name: Desktop Release ${{ inputs.version || github.ref_name }}
 
 on:
   push:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -83,7 +83,7 @@ jobs:
         run: npm test
 
       - name: Build desktop package
-        run: npm run desktop:dist
+        run: npm run desktop:dist -- --publish never
 
       - name: Verify Windows artifacts
         if: matrix.platform == 'windows'

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -68,10 +68,14 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Set package version
+        id: package
         shell: bash
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
+        run: |
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: npm ci
@@ -89,7 +93,7 @@ jobs:
         if: matrix.platform == 'windows'
         shell: pwsh
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.package.outputs.version }}
         run: |
           $required = @(
             "dist/desktop/SketchForge-Setup-$env:VERSION-x64.exe",
@@ -106,7 +110,7 @@ jobs:
         if: matrix.platform == 'linux'
         shell: bash
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.package.outputs.version }}
         run: |
           test -f "dist/desktop/SketchForge-$VERSION-x86_64.AppImage"
           test -f dist/desktop/latest-linux.yml
@@ -167,6 +171,16 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
+      - name: Normalize package version
+        id: package
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Ensure release tag exists
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -223,7 +237,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.package.outputs.version }}
         run: |
           assets=$(gh release view "$TAG" --json isDraft,assets)
           test "$(jq -r '.isDraft' <<< "$assets")" = "true"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -19,16 +19,26 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-and-release:
-    name: Build and publish Windows desktop
-    runs-on: windows-latest
+  build:
+    name: Build ${{ matrix.platform }} desktop
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows
+            runner: windows-latest
+            artifact: desktop-windows
+          - platform: linux
+            runner: ubuntu-latest
+            artifact: desktop-linux
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
-
     steps:
       - name: Check out source
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -38,44 +48,30 @@ jobs:
 
       - name: Resolve release version
         id: version
-        shell: pwsh
-        run: |
-          if ("${{ github.event_name }}" -eq "workflow_dispatch") {
-            $version = "${{ inputs.version }}".Trim().TrimStart("v")
-            $tag = "v$version"
-          } else {
-            $tag = "${{ github.ref_name }}"
-            $version = $tag.TrimStart("v")
-          }
-
-          if ($version -notmatch '^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
-            throw "Invalid release version: $version"
-          }
-
-          "version=$version" >> $env:GITHUB_OUTPUT
-          "tag=$tag" >> $env:GITHUB_OUTPUT
-          Write-Host "Building SketchForge $version ($tag)"
-
-      - name: Ensure release tag exists
-        if: github.event_name == 'workflow_dispatch'
-        shell: pwsh
+        shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.version.outputs.tag }}
+          INPUT_VERSION: ${{ inputs.version }}
+          TAG_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          git fetch --tags --force
-          if (git rev-parse $env:TAG 2>$null) {
-            Write-Host "$env:TAG already exists."
-          } else {
-            git tag $env:TAG $env:GITHUB_SHA
-            git push origin $env:TAG
-          }
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            version="${INPUT_VERSION#v}"
+          else
+            version="${TAG_NAME#v}"
+          fi
 
-      - name: Set package version from release tag
-        shell: pwsh
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release version: $version" >&2
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Set package version
+        shell: bash
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: npm version $env:VERSION --no-git-tag-version --allow-same-version
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Install dependencies
         run: npm ci
@@ -86,113 +82,166 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Build Windows desktop update
+      - name: Build desktop package
         run: npm run desktop:dist
 
-      - name: Verify updater artifacts
+      - name: Verify Windows artifacts
+        if: matrix.platform == 'windows'
         shell: pwsh
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          $installer = "dist/desktop/SketchForge-Setup-$env:VERSION-x64.exe"
-          $blockmap = "$installer.blockmap"
-          $latest = "dist/desktop/latest.yml"
-
-          foreach ($file in @($installer, $blockmap, $latest)) {
+          $required = @(
+            "dist/desktop/SketchForge-Setup-$env:VERSION-x64.exe",
+            "dist/desktop/SketchForge-Setup-$env:VERSION-x64.exe.blockmap",
+            "dist/desktop/latest.yml"
+          )
+          foreach ($file in $required) {
             if (-not (Test-Path $file -PathType Leaf)) {
-              throw "Missing updater artifact: $file"
+              throw "Missing Windows artifact: $file"
             }
           }
 
-          $metadata = Get-Content $latest -Raw
-          if ($metadata -notmatch "version:\s*$([regex]::Escape($env:VERSION))") {
-            throw "latest.yml does not contain version $env:VERSION"
-          }
+      - name: Verify Linux artifacts
+        if: matrix.platform == 'linux'
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          test -f "dist/desktop/SketchForge-$VERSION-x86_64.AppImage"
+          test -f dist/desktop/latest-linux.yml
 
-          $hash = (Get-FileHash $installer -Algorithm SHA256).Hash.ToLowerInvariant()
-          Write-Host "Installer SHA-256: $hash"
-          Write-Host "Installer size: $((Get-Item $installer).Length) bytes"
+      - name: Store Windows artifacts
+        if: matrix.platform == 'windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            dist/desktop/SketchForge-Setup-*-x64.exe
+            dist/desktop/SketchForge-Setup-*-x64.exe.blockmap
+            dist/desktop/latest.yml
+          if-no-files-found: error
+
+      - name: Store Linux artifacts
+        if: matrix.platform == 'linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            dist/desktop/SketchForge-*.AppImage
+            dist/desktop/latest-linux.yml
+          if-no-files-found: error
+
+  attach:
+    name: Attach packages to release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Resolve release metadata
+        id: version
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          TAG_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            version="${INPUT_VERSION#v}"
+            tag="v$version"
+          else
+            tag="$TAG_NAME"
+            version="${tag#v}"
+          fi
+
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release version: $version" >&2
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure release tag exists
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          git fetch --tags --force
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "$TAG already exists."
+          else
+            git tag "$TAG" "$SOURCE_SHA"
+            git push origin "$TAG"
+          fi
+
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-windows
+          path: dist/release
+
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-linux
+          path: dist/release
 
       - name: Create draft release
-        shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          $existing = gh release view $env:TAG --json isDraft 2>$null
-          if ($LASTEXITCODE -eq 0) {
-            $release = $existing | ConvertFrom-Json
-            if (-not $release.isDraft) {
-              throw "Release $env:TAG is already published. Refusing to replace a live updater release."
+          existing=$(gh release view "$TAG" --json isDraft 2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            is_draft=$(jq -r '.isDraft' <<< "$existing")
+            if [ "$is_draft" != "true" ]; then
+              echo "Release $TAG is already published. Refusing to replace it." >&2
+              exit 1
+            fi
+            echo "Using existing draft release $TAG."
+          else
+            gh release create "$TAG" --draft --verify-tag \
+              --title "SketchForge $VERSION" \
+              --notes "SketchForge desktop $VERSION"
+          fi
+
+      - name: Upload desktop packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: gh release upload "$TAG" dist/release/* --clobber
+
+      - name: Verify release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          assets=$(gh release view "$TAG" --json isDraft,assets)
+          test "$(jq -r '.isDraft' <<< "$assets")" = "true"
+          names=$(jq -r '.assets[].name' <<< "$assets")
+          for expected in \
+            "SketchForge-Setup-$VERSION-x64.exe" \
+            "SketchForge-Setup-$VERSION-x64.exe.blockmap" \
+            "latest.yml" \
+            "SketchForge-$VERSION-x86_64.AppImage" \
+            "latest-linux.yml"; do
+            grep -Fxq "$expected" <<< "$names" || {
+              echo "GitHub release is missing $expected" >&2
+              exit 1
             }
-            Write-Host "Using existing draft release $env:TAG."
-          } else {
-            gh release create $env:TAG --draft --verify-tag --title "SketchForge $env:VERSION" --notes "SketchForge desktop $env:VERSION"
-          }
+          done
 
-      - name: Upload updater assets to draft
-        shell: pwsh
+      - name: Publish release as latest
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          $installer = "dist/desktop/SketchForge-Setup-$env:VERSION-x64.exe"
-          gh release upload $env:TAG `
-            $installer `
-            "$installer.blockmap" `
-            "dist/desktop/latest.yml" `
-            --clobber
-
-      - name: Verify GitHub release assets
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.version.outputs.tag }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          $release = gh release view $env:TAG --json isDraft,assets | ConvertFrom-Json
-          if (-not $release.isDraft) {
-            throw "Release became public before verification."
-          }
-
-          $expected = @(
-            "SketchForge-Setup-$env:VERSION-x64.exe",
-            "SketchForge-Setup-$env:VERSION-x64.exe.blockmap",
-            "latest.yml"
-          )
-          $actual = @($release.assets | ForEach-Object { $_.name })
-
-          foreach ($name in $expected) {
-            if ($actual -notcontains $name) {
-              throw "GitHub release is missing $name"
-            }
-          }
-
-          if ($release.assets.Count -lt 3) {
-            throw "Expected at least 3 release assets."
-          }
-
-      - name: Publish release as Latest
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.version.outputs.tag }}
-        run: gh release edit $env:TAG --draft=false --latest
-
-      - name: Final release check
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          $release = gh release view $env:TAG --json tagName,isDraft,publishedAt,assets | ConvertFrom-Json
-          if ($release.isDraft) {
-            throw "Release $env:TAG is still a draft."
-          }
-          $latestTag = gh api "repos/$env:GITHUB_REPOSITORY/releases/latest" --jq '.tag_name'
-          if ($latestTag -ne $env:TAG) {
-            throw "Latest release is $latestTag instead of $env:TAG"
-          }
-          Write-Host "$env:TAG is published as Latest with $($release.assets.Count) assets."
+        run: gh release edit "$TAG" --draft=false --latest

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -33,8 +33,13 @@ jobs:
             runner: ubuntu-latest
             artifact: desktop-linux
           - platform: macos
-            runner: macos-latest
-            artifact: desktop-macos
+            runner: macos-15-intel
+            artifact: desktop-macos-x64
+            arch: x64
+          - platform: macos
+            runner: macos-14
+            artifact: desktop-macos-arm64
+            arch: arm64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     steps:
@@ -95,6 +100,7 @@ jobs:
         with:
           version: ${{ steps.package.outputs.version }}
           artifact-name: ${{ matrix.artifact }}
+          arch: ${{ matrix.arch }}
           csc-link: ${{ secrets.CSC_LINK }}
           csc-key-password: ${{ secrets.CSC_KEY_PASSWORD }}
           apple-api-key: ${{ secrets.APPLE_API_KEY }}
@@ -184,11 +190,45 @@ jobs:
           name: desktop-linux
           path: dist/release
 
-      - name: Download macOS artifacts
+      - name: Download macOS x64 artifacts
         uses: actions/download-artifact@v4
         with:
-          name: desktop-macos
-          path: dist/release
+          name: desktop-macos-x64
+          path: dist/release/macos-x64
+
+      - name: Download macOS arm64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-macos-arm64
+          path: dist/release/macos-arm64
+
+      - name: Merge macOS update manifests
+        shell: bash
+        run: |
+          npm ci --ignore-scripts
+          node <<'NODE'
+          const fs = require("node:fs");
+          const yaml = require("js-yaml");
+          const paths = [
+            "dist/release/macos-x64/latest-mac-x64.yml",
+            "dist/release/macos-arm64/latest-mac-arm64.yml",
+          ];
+          const manifests = paths.map((file) => yaml.load(fs.readFileSync(file, "utf8")));
+          const merged = {
+            ...manifests[0],
+            files: manifests.flatMap((manifest) => manifest.files || []),
+          };
+          delete merged.path;
+          delete merged.sha512;
+          fs.writeFileSync("dist/release/latest-mac.yml", yaml.dump(merged, { noRefs: true }));
+          for (const directory of ["macos-x64", "macos-arm64"]) {
+            for (const file of fs.readdirSync(`dist/release/${directory}`)) {
+              if (file === "latest-mac-x64.yml" || file === "latest-mac-arm64.yml") continue;
+              fs.renameSync(`dist/release/${directory}/${file}`, `dist/release/${file}`);
+            }
+            fs.rmSync(`dist/release/${directory}`, { recursive: true, force: true });
+          }
+          NODE
 
       - name: Create draft release
         env:
@@ -240,8 +280,10 @@ jobs:
             "latest.yml" \
             "SketchForge-$VERSION-x86_64.AppImage" \
             "latest-linux.yml" \
-            "SketchForge-$VERSION-universal${suffix}.dmg" \
-            "SketchForge-$VERSION-universal${suffix}.zip" \
+            "SketchForge-$VERSION-x64${suffix}.dmg" \
+            "SketchForge-$VERSION-x64${suffix}.zip" \
+            "SketchForge-$VERSION-arm64${suffix}.dmg" \
+            "SketchForge-$VERSION-arm64${suffix}.zip" \
             "latest-mac.yml"; do
             grep -Fxq "$expected" <<< "$names" || {
               echo "GitHub release is missing $expected" >&2

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -31,6 +31,9 @@ jobs:
           - platform: linux
             runner: ubuntu-latest
             artifact: desktop-linux
+          - platform: macos
+            runner: macos-latest
+            artifact: desktop-macos
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     steps:
@@ -86,55 +89,28 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Build desktop package
-        run: npm run desktop:dist -- --publish never
-
-      - name: Verify Windows artifacts
-        if: matrix.platform == 'windows'
-        shell: pwsh
-        env:
-          VERSION: ${{ steps.package.outputs.version }}
-        run: |
-          $required = @(
-            "dist/desktop/SketchForge-Setup-$env:VERSION-x64.exe",
-            "dist/desktop/SketchForge-Setup-$env:VERSION-x64.exe.blockmap",
-            "dist/desktop/latest.yml"
-          )
-          foreach ($file in $required) {
-            if (-not (Test-Path $file -PathType Leaf)) {
-              throw "Missing Windows artifact: $file"
-            }
-          }
-
-      - name: Verify Linux artifacts
-        if: matrix.platform == 'linux'
-        shell: bash
-        env:
-          VERSION: ${{ steps.package.outputs.version }}
-        run: |
-          test -f "dist/desktop/SketchForge-$VERSION-x86_64.AppImage"
-          test -f dist/desktop/latest-linux.yml
-
-      - name: Store Windows artifacts
-        if: matrix.platform == 'windows'
-        uses: actions/upload-artifact@v4
+      - uses: ./.github/actions/build-mac
+        if: matrix.platform == 'macos'
         with:
-          name: ${{ matrix.artifact }}
-          path: |
-            dist/desktop/SketchForge-Setup-*-x64.exe
-            dist/desktop/SketchForge-Setup-*-x64.exe.blockmap
-            dist/desktop/latest.yml
-          if-no-files-found: error
+          version: ${{ steps.package.outputs.version }}
+          artifact-name: ${{ matrix.artifact }}
+          csc-link: ${{ secrets.CSC_LINK }}
+          csc-key-password: ${{ secrets.CSC_KEY_PASSWORD }}
+          apple-api-key: ${{ secrets.APPLE_API_KEY }}
+          apple-api-key-id: ${{ secrets.APPLE_API_KEY_ID }}
+          apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
 
-      - name: Store Linux artifacts
+      - uses: ./.github/actions/build-linux
         if: matrix.platform == 'linux'
-        uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}
-          path: |
-            dist/desktop/SketchForge-*.AppImage
-            dist/desktop/latest-linux.yml
-          if-no-files-found: error
+          version: ${{ steps.package.outputs.version }}
+          artifact-name: ${{ matrix.artifact }}
+
+      - uses: ./.github/actions/build-win32
+        if: matrix.platform == 'windows'
+        with:
+          version: ${{ steps.package.outputs.version }}
+          artifact-name: ${{ matrix.artifact }}
 
   attach:
     name: Attach packages to release
@@ -207,6 +183,12 @@ jobs:
           name: desktop-linux
           path: dist/release
 
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-macos
+          path: dist/release
+
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -238,16 +220,28 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
           VERSION: ${{ steps.package.outputs.version }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: |
           assets=$(gh release view "$TAG" --json isDraft,assets)
           test "$(jq -r '.isDraft' <<< "$assets")" = "true"
           names=$(jq -r '.assets[].name' <<< "$assets")
+          suffix=""
+          if [[ -z "$CSC_LINK" || -z "$CSC_KEY_PASSWORD" || -z "$APPLE_API_KEY" || -z "$APPLE_API_KEY_ID" || -z "$APPLE_API_ISSUER" ]]; then
+            suffix="-unsigned"
+          fi
           for expected in \
             "SketchForge-Setup-$VERSION-x64.exe" \
             "SketchForge-Setup-$VERSION-x64.exe.blockmap" \
             "latest.yml" \
             "SketchForge-$VERSION-x86_64.AppImage" \
-            "latest-linux.yml"; do
+            "latest-linux.yml" \
+            "SketchForge-$VERSION-universal${suffix}.dmg" \
+            "SketchForge-$VERSION-universal${suffix}.zip" \
+            "latest-mac.yml"; do
             grep -Fxq "$expected" <<< "$names" || {
               echo "GitHub release is missing $expected" >&2
               exit 1

--- a/README.md
+++ b/README.md
@@ -65,6 +65,35 @@ There are two common ways to run SketchForge. If you are not sure which one to c
 
 SketchForge is local-first in both modes. The app files may be served from a computer or server, but projects stay in each user's browser storage. STL and OBJ exports download through the user's browser. SketchForge does not upload models to a SketchForge cloud service.
 
+## macOS Desktop Release
+
+GitHub releases include macOS DMG files for Intel (`x64`) and Apple Silicon (`arm64`) Macs. Choose the file that matches your Mac.
+
+1. Open the downloaded DMG file.
+2. Drag `SketchForge.app` to the `Applications` folder.
+3. Eject the DMG file.
+4. Control-click `SketchForge.app` in `Applications`.
+5. Select **Open**, then select **Open** again.
+
+Unsigned releases have `-unsigned` in the file name. macOS shows a Gatekeeper warning for these releases. If macOS does not show the **Open** option, run this command in Terminal:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/SketchForge.app
+open /Applications/SketchForge.app
+```
+
+Do not open the app from Safari's Downloads folder or directly from the mounted DMG. Copy it to `Applications` first.
+
+### macOS Virtual Machines
+
+Some macOS virtual machines do not provide hardware WebGL. Launch SketchForge with software WebGL in that case:
+
+```bash
+/Applications/SketchForge.app/Contents/MacOS/SketchForge \
+  --use-angle=swiftshader \
+  --enable-unsafe-swiftshader
+```
+
 ### Download the Project
 
 If you already know Git:

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -46,6 +46,7 @@ mac:
   artifactName: ${productName}-${version}-${arch}.${ext}
 
 linux:
+  syncDesktopName: true
   icon: apps/web/public/assets/sketchforge/sketchforge-logo.png
   target:
     - AppImage

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -42,6 +42,7 @@ mac:
   icon: apps/web/public/assets/sketchforge/sketchforge-logo.png
   target:
     - dmg
+    - zip
   category: public.app-category.graphics-design
   artifactName: ${productName}-${version}-${arch}.${ext}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@types/react-dom": "^19.1.5",
         "electron": "^43.4.0",
         "electron-builder": "^26.15.3",
+        "js-yaml": "^4.3.1",
         "typescript": "^5.8.3",
         "vitest": "^4.1.8"
       }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/react-dom": "^19.1.5",
     "electron": "^43.4.0",
     "electron-builder": "^26.15.3",
+    "js-yaml": "^4.3.1",
     "typescript": "^5.8.3",
     "vitest": "^4.1.8"
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "sketchforge",
   "version": "1.0.3",
   "private": true,
+  "description": "A local-first 3D design editor.",
+  "author": {
+    "name": "SketchForge contributors"
+  },
+  "homepage": "https://sketchforge3d.com",
+  "desktopName": "sketchforge",
   "main": "apps/desktop/main.cjs",
   "license": "AGPL-3.0-only",
   "scripts": {


### PR DESCRIPTION
## Summary

Build and publish Windows, Linux, and macOS desktop packages from one GitHub release workflow.

## Changes

- Split platform builds into reusable composite actions.
- Build Windows NSIS packages.
- Build Linux x64 AppImage packages.
- Build macOS universal DMG and ZIP packages.
- Publish the macOS `latest-mac.yml` updater manifest.
- Mark macOS artifacts `-unsigned` when signing or notarization secrets are missing.
- Document `Formsmith746/SketchForge-3D` release setup and macOS secrets in `.github/SETUP.md`.

## Testing

- [x] `actionlint` passes.
- [x] Composite action metadata checks pass.
- [x] `git diff --check` passes.
- [x] Windows, Linux, and macOS release builds run in GitHub Actions.
