### PR TITLE
fix: avoid Invalid string length crash when fingerprinting large imported meshes

### DIFF
--- a/apps/web/src/lib/editorHistory.ts
+++ b/apps/web/src/lib/editorHistory.ts
@@ -24,6 +24,7 @@ type ResourceSignature = {
 const resourceSignatureCache = new WeakMap<object, ResourceSignature>();
 const stringSignatureCache = new Map<string, ResourceSignature>();
 const MAX_CACHED_STRING_SIGNATURES = 64;
+const floatHashView = new DataView(new ArrayBuffer(8));
 const COMPACT_RESOURCE_KEYS = new Set([
   "cadDisplayEdges",
   "edgeTreatmentHistory",
@@ -47,10 +48,62 @@ function signatureFromSerialized(serialized: string): ResourceSignature {
   };
 }
 
+function hashChars(hashA: number, hashB: number, chunk: string) {
+  for (let index = 0; index < chunk.length; index += 1) {
+    const code = chunk.charCodeAt(index);
+    hashA = Math.imul(hashA ^ code, 16777619);
+    hashB = Math.imul(hashB, 33) ^ code;
+  }
+  return { hashA, hashB };
+}
+
+// Fallback for meshes too large to JSON.stringify in one string (throws
+// "RangeError: Invalid string length" past the JS engine's max string size).
+// Hashes each field independently -- large number arrays (positions/normals)
+// go through their float bit patterns instead of decimal text, so no single
+// string ever grows past one field's size.
+function signatureFromLargeResource(resource: object): ResourceSignature {
+  let hashA = 2166136261;
+  let hashB = 5381;
+  let length = 0;
+
+  const entries = Object.entries(resource as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
+  for (const [key, value] of entries) {
+    ({ hashA, hashB } = hashChars(hashA, hashB, key));
+    if (Array.isArray(value) && value.length > 10_000 && value.every((entry) => typeof entry === "number")) {
+      length += value.length;
+      for (let index = 0; index < value.length; index += 1) {
+        floatHashView.setFloat64(0, value[index] as number);
+        const hi = floatHashView.getUint32(0);
+        const lo = floatHashView.getUint32(4);
+        hashA = Math.imul(hashA ^ hi, 16777619);
+        hashA = Math.imul(hashA ^ lo, 16777619);
+        hashB = Math.imul(hashB, 33) ^ hi;
+        hashB = Math.imul(hashB, 33) ^ lo;
+      }
+      continue;
+    }
+    const chunk = JSON.stringify(value) ?? "";
+    length += chunk.length;
+    ({ hashA, hashB } = hashChars(hashA, hashB, chunk));
+  }
+
+  return {
+    fingerprint: `${length}:${hashA >>> 0}:${hashB >>> 0}`,
+    estimatedBytes: length * 2,
+  };
+}
+
 function objectResourceSignature(resource: object) {
   const cached = resourceSignatureCache.get(resource);
   if (cached) return cached;
-  const signature = signatureFromSerialized(JSON.stringify(resource));
+  let signature: ResourceSignature;
+  try {
+    signature = signatureFromSerialized(JSON.stringify(resource));
+  } catch (error) {
+    if (!(error instanceof RangeError)) throw error;
+    signature = signatureFromLargeResource(resource);
+  }
   resourceSignatureCache.set(resource, signature);
   return signature;
 }


### PR DESCRIPTION
## Title
fix: avoid Invalid string length crash when fingerprinting large imported meshes

## Description

Fixes #70

**Touches undo/redo history** (per CONTRIBUTING.md's "Areas That Need Care") — specifically the scene-fingerprinting logic used to dedupe/track history entries, not the undo/redo stack mechanics themselves. See Testing below for what was checked.

Importing a dense STL (large `positions`/`normals` number arrays on `importedMesh`) can throw `RangeError: Invalid string length` and silently fail the import. Root cause is in `objectResourceSignature()` (`apps/web/src/lib/editorHistory.ts`): it computes a compact fingerprint for undo-history tracking by calling `JSON.stringify(resource)` on the *entire* `importedMesh` object — the same large mesh data the compact-fingerprint scheme exists to avoid re-embedding in the outer scene JSON. For a mesh with ~6M vertices, that single `JSON.stringify` call builds a string past the JS engine's max string length.

## Change

- `objectResourceSignature()` still tries the existing `JSON.stringify` fast path first — unchanged for every normal-sized resource.
- On a `RangeError` specifically, it falls back to a new `signatureFromLargeResource()` that hashes the object field-by-field instead of building one big string. Number arrays over 10k elements are hashed via their float64 bit patterns (`DataView`) rather than decimal text; every other field still goes through `JSON.stringify` per-field, which stays small.
- No behavior change for any object that doesn't hit the crash today.

## Testing

- `npm run typecheck` passes clean.
- Reproduced the crash locally with a ~99MB / ~1.99M-triangle binary STL (verified as a well-formed binary STL independently — header triangle count matches file size exactly, so this isn't a malformed-file issue).
- Confirmed the crash disappears with this patch: the same file imports cleanly (dashboard shows `shapes: 1`, status `Ready`, no console errors).
- Spot-checked undo/redo and the dashboard project list still behave normally after the change.
- Did not add an automated regression test yet (would need a large synthetic mesh fixture) — happy to add one if useful, e.g. under `tests/unit/`.
