### PR TITLE
fix(desktop): quit on Linux window close, add .desktop metadata and Linux docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,47 @@ There are two common ways to run SketchForge. If you are not sure which one to c
 
 SketchForge is local-first in both modes. The app files may be served from a computer or server, but projects stay in each user's browser storage. STL and OBJ exports download through the user's browser. SketchForge does not upload models to a SketchForge cloud service.
 
+## Linux Desktop Release
+
+GitHub releases include a Linux AppImage for 64-bit Intel and AMD machines (`x86_64`). An AppImage is a single file that runs without installation.
+
+1. Download `SketchForge-<version>-x86_64.AppImage`.
+2. Mark it executable.
+3. Run it.
+
+```bash
+chmod +x SketchForge-*-x86_64.AppImage
+./SketchForge-*-x86_64.AppImage
+```
+
+To get a menu entry and an icon, install [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher) and open the AppImage once. AppImageLauncher moves the file to a fixed location and registers it with the desktop.
+
+Closing the SketchForge window quits the application. On desktops that provide a system tray, SketchForge also adds a tray icon while it runs.
+
+### Ubuntu 24.04 and Debian 13
+
+These releases restrict unprivileged user namespaces, which the Chromium sandbox inside Electron needs. Starting the AppImage from a terminal then fails, often without a visible error. Check whether the restriction is active:
+
+```bash
+sysctl kernel.apparmor_restrict_unprivileged_userns
+```
+
+If the value is `1`, start SketchForge from the application menu. The bundled launcher entry already handles this case. To start it from a terminal on these systems, either add an AppArmor profile for the AppImage, or pass `--no-sandbox`:
+
+```bash
+./SketchForge-*-x86_64.AppImage --no-sandbox
+```
+
+### Linux Virtual Machines
+
+Some virtual machines do not provide hardware WebGL. Launch SketchForge with software WebGL in that case:
+
+```bash
+./SketchForge-*-x86_64.AppImage \
+  --use-angle=swiftshader \
+  --enable-unsafe-swiftshader
+```
+
 ## macOS Desktop Release
 
 GitHub releases include macOS DMG files for Intel (`x64`) and Apple Silicon (`arm64`) Macs. Choose the file that matches your Mac.

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -56,6 +56,5 @@ linux:
   desktop:
     entry:
       GenericName: 3D Design Editor
-      Comment: Design and export 3D models locally
       Keywords: 3D;CAD;Model;Modelling;STL;OBJ;STEP;3D Printing;Design;
-      StartupWMClass: SketchForge
+      StartupWMClass: sketchforge

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -53,3 +53,9 @@ linux:
     - AppImage
   category: Graphics
   artifactName: ${productName}-${version}-${arch}.${ext}
+  desktop:
+    entry:
+      GenericName: 3D Design Editor
+      Comment: Design and export 3D models locally
+      Keywords: 3D;CAD;Model;Modelling;STL;OBJ;STEP;3D Printing;Design;
+      StartupWMClass: SketchForge

--- a/apps/desktop/main.cjs
+++ b/apps/desktop/main.cjs
@@ -10,6 +10,8 @@ const devUrl = process.env.SKETCHFORGE_DESKTOP_DEV_URL?.trim() || "";
 // vanish after every restart.
 const DESKTOP_PORT = Number.parseInt(process.env.SKETCHFORGE_DESKTOP_PORT || "62158", 10);
 
+const isLinux = process.platform === "linux";
+
 let mainWindow = null;
 let tray = null;
 let webServer = null;
@@ -256,8 +258,17 @@ function setupDesktopUpdater() {
 function createTray() {
   if (tray) return;
 
-  const icon = nativeImage.createFromPath(appIconPath()).resize({ width: 20, height: 20 });
-  tray = new Tray(icon);
+  let icon;
+  try {
+    icon = nativeImage.createFromPath(appIconPath()).resize({ width: 20, height: 20 });
+    tray = new Tray(icon);
+  } catch (error) {
+    // Several Linux desktops ship no StatusNotifier host, so the tray is a
+    // bonus rather than a requirement. Never let it block startup.
+    console.warn(`SketchForge could not create a tray icon: ${error instanceof Error ? error.message : String(error)}`);
+    return;
+  }
+
   tray.setToolTip("SketchForge");
   tray.setContextMenu(Menu.buildFromTemplate([
     {
@@ -338,6 +349,10 @@ function createMainWindow(url) {
 
   mainWindow.on("close", (event) => {
     if (isQuitting) return;
+    // Hiding to the tray is only safe where a tray is dependable. GNOME has no
+    // StatusNotifier host without an extension, so a hidden window would leave
+    // SketchForge running with no way to reopen or quit it.
+    if (isLinux) return;
     event.preventDefault();
     mainWindow?.hide();
   });
@@ -398,4 +413,7 @@ app.on("before-quit", () => {
 app.on("window-all-closed", () => {
   // Keep SketchForge available from the system tray. Use Quit SketchForge
   // from the tray menu when the user wants to fully stop the application.
+  // Linux desktops cannot rely on a tray, and closing the last window is the
+  // expected way to quit there, so honour that instead.
+  if (isLinux) app.quit();
 });


### PR DESCRIPTION
## Summary

- Closing the SketchForge window now quits the app on Linux. The `close` handler hid the window instead, and `window-all-closed` deliberately did nothing, so the app stayed reachable only through the tray. GNOME ships no StatusNotifier host without an extension, so on those desktops SketchForge became invisible with no way to reopen or quit it. Windows and macOS keep the existing hide-to-tray behaviour.
- Tray creation no longer aborts startup when the desktop provides no tray.
- Added `.desktop` metadata (`GenericName`, `Keywords`, `StartupWMClass`) so launchers show a useful entry and the running window maps back to it.
- Added a Linux section to the README, mirroring the existing macOS one: running the AppImage, getting a launcher entry, the unprivileged user namespace restriction on Ubuntu 24.04 / Debian 13, and the software WebGL fallback for VMs.

No changes to the packaging targets, the release workflow, or the updater.

## Testing

- [x] `npm run typecheck`
- [x] Manually tested the affected workflow

Built `SketchForge-1.0.8-x86_64.AppImage` with `npm run desktop:dist -- --publish never --linux --x64` on `ubuntu-latest` and ran it on Linux Mint 22.3 (Cinnamon, X11):

- Editor loads, packaged Next.js server starts as before.
- Closing the window terminates the app; no orphaned `sketchforge` or web server processes remain.
- `desktop-file-validate` passes on the generated `sketchforge.desktop`.
- `xprop WM_CLASS` on the running window reports `"sketchforge", "sketchforge"`, which is what `StartupWMClass` is set to.

## Notes

- `StartupWMClass` is intentionally lowercase. Electron derives `WM_CLASS` from the executable name, so `SketchForge` would not have matched.
- I did not set `Comment` in `electron-builder.yml`, because electron-builder always overwrites it with the `description` from `package.json`.
- Out of scope here, but noticed while testing: the AppImage's auto-updater cannot find `latest-linux.yml`. The newest published release is `v1.0.3` and it only carries the Windows assets, so the Linux and macOS artifacts the release workflow builds have not reached a release yet. Happy to open a separate issue if that is useful.
