### PR TITLE
fix: give the rotate handle its own cursor

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -4800,7 +4800,9 @@ button {
   border: 0;
   border-radius: 0;
   box-shadow: none;
-  cursor: grab;
+  /* Not grab: the canvas itself already uses grab for orbiting, so the
+     rotate handle would be the only control that gives no hover feedback. */
+  cursor: pointer;
   opacity: 1;
   transform: translate3d(var(--overlay-x, 0), var(--overlay-y, 0), 0) translate(-50%, -50%);
 }


### PR DESCRIPTION
The rotate handle is the only transform control that gives no hover feedback: its cursor is identical to the canvas cursor.

Measured in a production build with `getComputedStyle`:

| element | cursor |
|---|---|
| canvas / scene | `grab` |
| rotate handle | `grab` |
| corner scale handle | `nwse-resize` |
| height / lift handle | `ns-resize` |

Moving the pointer from empty space onto the rotate handle changes nothing on screen, while every other handle announces itself. Until the drag starts, there is no way to tell whether it will rotate the shape or orbit the camera.

The shared rule at `globals.css:4733` already assigns a resize cursor to both handle families; only the later `.rotate-handle` block overrides it back to `grab`.

`pointer` is the least opinionated fix — it means "interactive control" and, unlike `grab`, differs from the canvas. A dedicated rotation cursor would read better still, but that is a design decision I did not want to make on your behalf.

One line changed, plus a comment explaining why it is not `grab`.

Found by a user while working in the editor, not while reading the code.
