### PR TITLE
fix: refresh generated tooltips when the accessible name changes

### DIFF
--- a/apps/web/src/components/SketchForgeEditor.tsx
+++ b/apps/web/src/components/SketchForgeEditor.tsx
@@ -88,6 +88,7 @@ import { appendEditorHistorySnapshot, boundedEditorHistoryState, editorHistoryEn
 import { snapShapeFootprintToVisibleGrid, visibleGridStep } from "@/lib/gridSnap";
 import { geometryRotationDegreesForShortcut, geometryRotationDelta, rotatedGeometryShapePatch } from "@/lib/geometryRotation";
 import { createLocalId } from "@/lib/localIds";
+import { createButtonTooltipSync } from "@/lib/buttonTooltips";
 import { projectExportFileName } from "@/lib/exportNames";
 import { exportMeshesToObj } from "@/lib/objExport";
 import { rotateSketchPoints, selectedClosedSketchPoints } from "@/lib/sketchRotation";
@@ -5754,16 +5755,9 @@ export function SketchForgeEditor({
   }, []);
 
   useEffect(() => {
+    const syncButtonTooltips = createButtonTooltipSync();
     const applyTitles = () => {
-      document.querySelectorAll<HTMLButtonElement>("button").forEach((button) => {
-        if (button.title) {
-          return;
-        }
-        const label = button.getAttribute("aria-label") ?? button.textContent?.trim();
-        if (label) {
-          button.title = label.replace(/\s+/g, " ");
-        }
-      });
+      syncButtonTooltips(document.querySelectorAll<HTMLButtonElement>("button"));
     };
 
     applyTitles();

--- a/apps/web/src/lib/buttonTooltips.ts
+++ b/apps/web/src/lib/buttonTooltips.ts
@@ -1,0 +1,22 @@
+export type TooltipButton = Pick<HTMLButtonElement, "title" | "textContent" | "getAttribute">;
+
+export function buttonTooltipFromLabel(button: TooltipButton): string | null {
+  const label = button.getAttribute("aria-label") ?? button.textContent?.trim();
+  return label ? label.replace(/\s+/g, " ") : null;
+}
+
+export function createButtonTooltipSync() {
+  const written = new WeakMap<TooltipButton, string>();
+
+  return function syncButtonTooltips(buttons: Iterable<TooltipButton>) {
+    for (const button of buttons) {
+      const current = button.title;
+      // A title authored in the markup wins: only tooltips this helper wrote are refreshed.
+      if (current && written.get(button) !== current) continue;
+      const next = buttonTooltipFromLabel(button);
+      if (!next || next === current) continue;
+      button.title = next;
+      written.set(button, next);
+    }
+  };
+}

--- a/tests/unit/buttonTooltips.test.ts
+++ b/tests/unit/buttonTooltips.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { buttonTooltipFromLabel, createButtonTooltipSync, type TooltipButton } from "@/lib/buttonTooltips";
+
+function fakeButton(options: { title?: string; ariaLabel?: string; text?: string } = {}) {
+  const attributes = new Map<string, string>();
+  if (options.ariaLabel !== undefined) attributes.set("aria-label", options.ariaLabel);
+  return {
+    title: options.title ?? "",
+    textContent: options.text ?? null,
+    getAttribute: (name: string) => attributes.get(name) ?? null,
+    setAriaLabel: (value: string) => attributes.set("aria-label", value),
+  } satisfies TooltipButton & { setAriaLabel: (value: string) => void };
+}
+
+describe("button tooltips", () => {
+  it("derives the tooltip from the accessible name and collapses whitespace", () => {
+    expect(buttonTooltipFromLabel(fakeButton({ ariaLabel: "Lock shape" }))).toBe("Lock shape");
+    expect(buttonTooltipFromLabel(fakeButton({ text: "  Add\n  shape  " }))).toBe("Add shape");
+    expect(buttonTooltipFromLabel(fakeButton({ ariaLabel: "Top view", text: "TOP" }))).toBe("Top view");
+    expect(buttonTooltipFromLabel(fakeButton())).toBeNull();
+    expect(buttonTooltipFromLabel(fakeButton({ text: "   " }))).toBeNull();
+  });
+
+  it("refreshes a generated tooltip when the accessible name changes", () => {
+    const sync = createButtonTooltipSync();
+    const lock = fakeButton({ ariaLabel: "Lock shape" });
+
+    sync([lock]);
+    expect(lock.title).toBe("Lock shape");
+
+    lock.setAriaLabel("Unlock shape");
+    sync([lock]);
+    expect(lock.title).toBe("Unlock shape");
+  });
+
+  it("never overwrites a tooltip that came from the markup", () => {
+    const sync = createButtonTooltipSync();
+    // Real examples: title="Top view (5)" with aria-label="Top view", title="Undo" with aria-label="Sketch undo".
+    const view = fakeButton({ title: "Top view (5)", ariaLabel: "Top view", text: "TOP" });
+    const image = fakeButton({ title: "Unlock image before deleting", ariaLabel: "Delete sketch image" });
+
+    sync([view, image]);
+    expect(view.title).toBe("Top view (5)");
+    expect(image.title).toBe("Unlock image before deleting");
+
+    image.setAriaLabel("Delete sketch image now");
+    sync([view, image]);
+    expect(image.title).toBe("Unlock image before deleting");
+  });
+
+  it("stops managing a tooltip once the markup claims it", () => {
+    const sync = createButtonTooltipSync();
+    const button = fakeButton({ ariaLabel: "Hide shape" });
+
+    sync([button]);
+    expect(button.title).toBe("Hide shape");
+
+    button.title = "Hide shape (H)";
+    button.setAriaLabel("Show shape");
+    sync([button]);
+    expect(button.title).toBe("Hide shape (H)");
+  });
+
+  it("leaves buttons without an accessible name alone", () => {
+    const sync = createButtonTooltipSync();
+    const blank = fakeButton();
+
+    sync([blank]);
+    expect(blank.title).toBe("");
+  });
+});


### PR DESCRIPTION
The effect in `SketchForgeEditor.tsx` that copies a button's accessible name into its `title` returns early on every button that already has one:

```js
if (button.title) {
  return;
}
```

The `MutationObserver` right below it watches `aria-label` on the whole subtree, so the intent to keep the tooltip in step with the name is clearly there. But the guard makes the observer a no-op: the first pass gives each unlabelled button a title, and every later pass hits the guard and leaves. A generated tooltip is written once and never again.

**Where it shows.** Toggle buttons, whose accessible name is the thing that changes. `ShapeInspector.tsx:480,483`:

```jsx
aria-label={locked ? "Unlock shape" : "Lock shape"}
aria-label={shape.hidden ? "Show shape" : "Hide shape"}
```

After one click the tooltip states the opposite of what the button will do: hovering the lock on an already-locked shape reads "Lock shape", and clicking it unlocks. The sketch image lock in `SketchWorkspace.tsx:1241` behaves the same way. Found in a production build, by hovering, not by reading code.

**Why the guard cannot simply go.** I walked the JSX with the TypeScript parser rather than trusting grep. Of 152 `<button>` elements in `apps/web/src`, 53 set `title` in the markup, and on **23** of those the title deliberately differs from the accessible name:

| Site | `title` | accessible name |
|---|---|---|
| `WorkplaneViewport.tsx:5048-5053` (view cube, 6 buttons) | `Top view (5)` | `Top view` |
| `WorkplaneViewport.tsx:5077` | `Place workplane (W)` | `Place workplane` |
| `WorkplaneViewport.tsx:5059,5064` | `Show controls` | `Show camera controls` |
| `SketchForgeEditor.tsx:9983` | `Add box at the sketch origin, or drag it onto the sketch` | `Box` (from the span) |
| `SketchForgeEditor.tsx:10032,10035` | `Undo` | `Sketch undo` |
| `ShapeInspector.tsx:528` | `#D41721` | `Set color #d41721` |
| `SketchWorkspace.tsx:1238` | `Lock image (L)` | `Lock sketch image` |
| `SketchWorkspace.tsx:1247` | `Unlock image before deleting` | `Delete sketch image` |
| `TransformOverlay.tsx:215,251` | `Rotate` | none at all |
| `page.tsx:1771,1873` | `Project options` | `Project options for <name>` |

Overwriting those would lose every keyboard shortcut hint in the viewport, so the fix has to tell "this tooltip was generated" from "this tooltip was authored".

**What this does.** The helper remembers what it wrote in a `WeakMap` keyed by the element and refreshes only a title that still matches its own last value. A title that came from the markup, or one that changed behind its back, is left alone. Buttons with a markup title take the same cheap early exit as before, so the observer's hot path is unchanged, and nothing is added to the DOM.

The logic moves into `src/lib/buttonTooltips.ts` so it can be covered by a unit test in the existing style; the effect in `SketchForgeEditor.tsx` is three lines now. If you would rather keep it inline, say so and I will fold it back — the `WeakMap` is the only part that matters.

Transcribing the shipped `applyTitles()` body verbatim into a scratch test and asserting the refresh makes it fail on `Lock shape` where `Unlock shape` is expected, which is the regression the new test pins down.

269 tests pass, the 264 existing ones plus five new; `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAoEuBEJyJtkEGapsp6G22
