### PR TITLE
feat: move shapes with the arrow keys the way the camera sees them

### DIFF
--- a/apps/web/src/components/SketchForgeEditor.tsx
+++ b/apps/web/src/components/SketchForgeEditor.tsx
@@ -115,6 +115,7 @@ import {
   type PlacementPoint,
   type PlacementWorkplane,
 } from "@/lib/placementWorkplane";
+import { DEFAULT_CAMERA_ORIENTATION, screenAlignedNudge, type CameraOrientation } from "@/lib/screenAlignedNudge";
 import { placeSketchExtrusion } from "@/lib/sketchPlacement";
 import {
   SKETCHFORGE_MCP_HEARTBEAT_MS,
@@ -8840,12 +8841,18 @@ export function SketchForgeEditor({
     });
   }, []);
 
+  const cameraOrientationRef = useRef<CameraOrientation>(DEFAULT_CAMERA_ORIENTATION);
+  const rememberCameraOrientation = useCallback((orientation: CameraOrientation) => {
+    cameraOrientationRef.current = orientation;
+  }, []);
+
   const nudgeSelected = useCallback(
-    (deltaX: number, deltaZ: number) => {
+    (screenRight: number, screenDown: number) => {
       if (!hasSelection) {
         return;
       }
       const selected = new Set(selectedIds);
+      const { x: deltaX, z: deltaZ } = screenAlignedNudge(placementWorkplane, cameraOrientationRef.current, screenRight, screenDown);
       const translation = {
         x: placementWorkplane.xAxis.x * deltaX + placementWorkplane.zAxis.x * deltaZ,
         y: placementWorkplane.xAxis.y * deltaX + placementWorkplane.zAxis.y * deltaZ,
@@ -9258,6 +9265,7 @@ export function SketchForgeEditor({
           onSetPlacementWorkplane={setViewportPlacementWorkplane}
           onToggleWorkplaneTool={activateWorkplaneTool}
           onInteractionActiveChange={updateProjectInteractionActive}
+          onCameraOrientationChange={rememberCameraOrientation}
           onEditSketch={beginSketchEdit}
           canSeparateParts={canSeparateSelectedParts}
           onSeparateParts={separateSelectedParts}

--- a/apps/web/src/components/WorkplaneViewport.tsx
+++ b/apps/web/src/components/WorkplaneViewport.tsx
@@ -42,6 +42,7 @@ import {
   type PlacementWorkplane,
 } from "@/lib/placementWorkplane";
 import { regularPolygonFootprintScale } from "@/lib/regularPolygonFootprint";
+import type { CameraOrientation } from "@/lib/screenAlignedNudge";
 import { projectThumbnailDimensions } from "@/lib/projectThumbnail";
 import { canBeginShapeDrag, DEFAULT_SNAP_GRID, DEFAULT_WORKPLANE_WORKSPACE, normalizeSnapGrid, normalizeWorkspaceSettings, shapeDimensionLimit, workplaneSettingsFingerprint, workspaceHydrationSyncDecision } from "@/lib/workplaneSettings";
 import { interiorWorkplaneGridCoordinates, workplaneThemePalette, WORKPLANE_LINE_ELEVATION, WORKPLANE_MAJOR_GRID_INTERVAL } from "@/lib/workplaneGrid";
@@ -206,6 +207,8 @@ type WorkplaneViewportProps = {
   onSetPlacementWorkplane: (workplane: PlacementWorkplane, source: "shape" | "base") => void;
   onToggleWorkplaneTool: () => void;
   onInteractionActiveChange?: (active: boolean) => void;
+  /** Fires while the camera moves, so keep it out of state and park it in a ref. */
+  onCameraOrientationChange?: (orientation: CameraOrientation) => void;
   onEditSketch?: () => void;
   canSeparateParts?: boolean;
   onSeparateParts?: () => void;
@@ -2375,6 +2378,7 @@ export function WorkplaneViewport({
   onSetPlacementWorkplane,
   onToggleWorkplaneTool,
   onInteractionActiveChange,
+  onCameraOrientationChange,
   onEditSketch,
   canSeparateParts = false,
   onSeparateParts,
@@ -2491,6 +2495,9 @@ export function WorkplaneViewport({
 
   const resolvedThemeRef = useRef(resolvedTheme);
   resolvedThemeRef.current = resolvedTheme;
+
+  const onCameraOrientationChangeRef = useRef(onCameraOrientationChange);
+  onCameraOrientationChangeRef.current = onCameraOrientationChange;
 
   const clearMoveDimensions = useCallback(() => {
     moveDimensionSessionRef.current = null;
@@ -2952,6 +2959,7 @@ export function WorkplaneViewport({
       state.camera.updateMatrixWorld();
       if (now - state.lastViewCubeSync > 48 || cameraSettled || state.needsRender) {
         syncViewCube(state, viewCubeRef.current);
+        onCameraOrientationChangeRef.current?.(cameraOrientation(state));
         state.lastViewCubeSync = now;
       }
       if (controlsChanged || cameraSettled || state.needsRender || now - state.lastOverlaySync > 96) {
@@ -5538,16 +5546,25 @@ function constrainCamera(state: ThreeState, workspace: WorkspaceSettings) {
   }
 }
 
+// Straight down and straight up leave no horizontal offset to read a yaw from, and
+// atan2(0, 0) returns 0. That is the answer we want: with the camera on the pole
+// THREE.Matrix4.lookAt breaks the tie towards the same axes as the Front view.
+function cameraOrientation(state: ThreeState): CameraOrientation {
+  const offset = state.camera.position.clone().sub(state.controls.target);
+  const horizontalDistance = Math.max(0.001, Math.hypot(offset.x, offset.z));
+  return {
+    yawDegrees: THREE.MathUtils.radToDeg(Math.atan2(offset.x, offset.z)),
+    pitchDegrees: THREE.MathUtils.radToDeg(Math.atan2(offset.y, horizontalDistance)),
+  };
+}
+
 function syncViewCube(state: ThreeState, cube: HTMLDivElement | null) {
   if (!cube) {
     return;
   }
 
-  const offset = state.camera.position.clone().sub(state.controls.target);
-  const horizontalDistance = Math.max(0.001, Math.hypot(offset.x, offset.z));
-  const pitch = THREE.MathUtils.radToDeg(Math.atan2(offset.y, horizontalDistance));
-  const yaw = THREE.MathUtils.radToDeg(Math.atan2(offset.x, offset.z));
-  cube.style.transform = `rotateX(${-pitch}deg) rotateY(${-yaw}deg)`;
+  const { yawDegrees, pitchDegrees } = cameraOrientation(state);
+  cube.style.transform = `rotateX(${-pitchDegrees}deg) rotateY(${-yawDegrees}deg)`;
 }
 
 function setObjectRenderLayer(object: THREE.Object3D, layer: number) {

--- a/apps/web/src/lib/screenAlignedNudge.ts
+++ b/apps/web/src/lib/screenAlignedNudge.ts
@@ -1,0 +1,66 @@
+import type { PlacementWorkplane } from "@/lib/placementWorkplane";
+
+export type CameraOrientation = {
+  yawDegrees: number;
+  pitchDegrees: number;
+};
+
+/** A camera parked on the Front face, the mapping arrow keys used before they followed the view. */
+export const DEFAULT_CAMERA_ORIENTATION: CameraOrientation = { yawDegrees: 0, pitchDegrees: 0 };
+
+const QUARTER_TURN_DEGREES = 90;
+
+// Exact values, so a quarter turn never leaks 6e-17 into a coordinate.
+const QUARTER_TURN_COS = [1, 0, -1, 0];
+const QUARTER_TURN_SIN = [0, 1, 0, -1];
+
+/**
+ * How many quarter turns of the scene the camera looks at, 0 for the Front view.
+ *
+ * A yaw exactly between two axes rounds down, which keeps the default
+ * three-quarter home view (yaw 45) on the axes it has always used.
+ */
+function quarterTurnsFacingCamera(yawDegrees: number) {
+  if (!Number.isFinite(yawDegrees)) {
+    return 0;
+  }
+  const turns = Math.ceil(yawDegrees / QUARTER_TURN_DEGREES - 0.5);
+  return ((turns % 4) + 4) % 4;
+}
+
+/** A quarter turn can leave a negative zero behind, which nothing downstream wants. */
+function positiveZero(value: number) {
+  return value === 0 ? 0 : value;
+}
+
+function followsCamera(workplane: PlacementWorkplane) {
+  // Only the flat ground plane has no orientation of its own. A workplane laid
+  // on a face keeps its own axes, otherwise its arrows would leave that face.
+  return Math.abs(Math.abs(workplane.normal.y) - 1) < 1e-6;
+}
+
+/**
+ * Turns an arrow key, read as a screen direction, into a step along the workplane
+ * axes: right and down on screen at the Front view, and at any other view the
+ * axis closest to that screen direction.
+ */
+export function screenAlignedNudge(
+  workplane: PlacementWorkplane,
+  camera: CameraOrientation,
+  screenRight: number,
+  screenDown: number,
+) {
+  if (!followsCamera(workplane)) {
+    return { x: screenRight, z: screenDown };
+  }
+  const turns = quarterTurnsFacingCamera(camera.yawDegrees);
+  const cos = QUARTER_TURN_COS[turns];
+  const sin = QUARTER_TURN_SIN[turns];
+  // Seen from below the horizon the scene is mirrored, so screen down points the
+  // other way. Screen right is unaffected: it never depends on the pitch.
+  const down = camera.pitchDegrees >= 0 ? screenDown : -screenDown;
+  return {
+    x: positiveZero(screenRight * cos + down * sin),
+    z: positiveZero(down * cos - screenRight * sin),
+  };
+}

--- a/tests/unit/screenAlignedNudge.test.ts
+++ b/tests/unit/screenAlignedNudge.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import { horizontalPlacementWorkplane, placementWorkplaneFromSurface } from "@/lib/placementWorkplane";
+import { DEFAULT_CAMERA_ORIENTATION, screenAlignedNudge } from "@/lib/screenAlignedNudge";
+
+const BASE = horizontalPlacementWorkplane();
+
+const LEFT = { right: -1, down: 0 };
+const RIGHT = { right: 1, down: 0 };
+const UP = { right: 0, down: -1 };
+const DOWN = { right: 0, down: 1 };
+
+function nudge(arrow: { right: number; down: number }, yawDegrees: number, pitchDegrees = 35) {
+  return screenAlignedNudge(BASE, { yawDegrees, pitchDegrees }, arrow.right, arrow.down);
+}
+
+describe("screenAlignedNudge", () => {
+  it("keeps the world axes at the Front view", () => {
+    expect(nudge(RIGHT, 0)).toEqual({ x: 1, z: 0 });
+    expect(nudge(LEFT, 0)).toEqual({ x: -1, z: 0 });
+    expect(nudge(DOWN, 0)).toEqual({ x: 0, z: 1 });
+    expect(nudge(UP, 0)).toEqual({ x: 0, z: -1 });
+  });
+
+  it("keeps the world axes at the default home view", () => {
+    expect(nudge(RIGHT, 45, 39.2)).toEqual({ x: 1, z: 0 });
+    expect(nudge(DOWN, 45, 39.2)).toEqual({ x: 0, z: 1 });
+  });
+
+  it("turns the arrows with the camera at the Right view", () => {
+    expect(nudge(RIGHT, 90)).toEqual({ x: 0, z: -1 });
+    expect(nudge(LEFT, 90)).toEqual({ x: 0, z: 1 });
+    expect(nudge(DOWN, 90)).toEqual({ x: 1, z: 0 });
+    expect(nudge(UP, 90)).toEqual({ x: -1, z: 0 });
+  });
+
+  it("turns the arrows with the camera at the Back view", () => {
+    expect(nudge(RIGHT, 180)).toEqual({ x: -1, z: 0 });
+    expect(nudge(DOWN, 180)).toEqual({ x: 0, z: -1 });
+  });
+
+  it("turns the arrows with the camera at the Left view", () => {
+    expect(nudge(RIGHT, -90)).toEqual({ x: 0, z: 1 });
+    expect(nudge(DOWN, -90)).toEqual({ x: -1, z: 0 });
+  });
+
+  it("rounds a yaw sitting exactly between two axes down to the lower one", () => {
+    expect(nudge(RIGHT, 44.9)).toEqual({ x: 1, z: 0 });
+    expect(nudge(RIGHT, 45)).toEqual({ x: 1, z: 0 });
+    expect(nudge(RIGHT, 45.1)).toEqual({ x: 0, z: -1 });
+
+    expect(nudge(RIGHT, 135)).toEqual({ x: 0, z: -1 });
+    expect(nudge(RIGHT, 135.1)).toEqual({ x: -1, z: 0 });
+
+    expect(nudge(RIGHT, -45)).toEqual({ x: 0, z: 1 });
+    expect(nudge(RIGHT, -44.9)).toEqual({ x: 1, z: 0 });
+  });
+
+  it("reads negative yaw the same as its positive turn", () => {
+    for (const arrow of [LEFT, RIGHT, UP, DOWN]) {
+      expect(nudge(arrow, -90)).toEqual(nudge(arrow, 270));
+      expect(nudge(arrow, -180)).toEqual(nudge(arrow, 180));
+      expect(nudge(arrow, -270)).toEqual(nudge(arrow, 90));
+    }
+  });
+
+  it("repeats itself every full turn", () => {
+    for (let yawDegrees = -180; yawDegrees <= 180; yawDegrees += 7.5) {
+      for (const arrow of [LEFT, RIGHT, UP, DOWN]) {
+        expect(nudge(arrow, yawDegrees + 360)).toEqual(nudge(arrow, yawDegrees));
+        expect(nudge(arrow, yawDegrees - 720)).toEqual(nudge(arrow, yawDegrees));
+      }
+    }
+  });
+
+  it("keeps the Front view axes when looking straight down, where there is no yaw to read", () => {
+    expect(nudge(RIGHT, 0, 90)).toEqual({ x: 1, z: 0 });
+    expect(nudge(DOWN, 0, 90)).toEqual({ x: 0, z: 1 });
+  });
+
+  it("mirrors the vertical arrows below the horizon, because the view is mirrored there", () => {
+    expect(nudge(RIGHT, 0, -90)).toEqual({ x: 1, z: 0 });
+    expect(nudge(LEFT, 0, -90)).toEqual({ x: -1, z: 0 });
+    expect(nudge(DOWN, 0, -90)).toEqual({ x: 0, z: -1 });
+    expect(nudge(UP, 0, -90)).toEqual({ x: 0, z: 1 });
+
+    expect(nudge(DOWN, 90, -30)).toEqual({ x: -1, z: 0 });
+  });
+
+  it("always moves along one axis by the full step, never diagonally", () => {
+    for (let yawDegrees = -360; yawDegrees <= 360; yawDegrees += 3) {
+      for (const arrow of [LEFT, RIGHT, UP, DOWN]) {
+        const step = nudge(arrow, yawDegrees);
+        expect([step.x, step.z].filter((value) => value !== 0)).toHaveLength(1);
+        expect(Math.abs(step.x) + Math.abs(step.z)).toBe(1);
+      }
+    }
+  });
+
+  it("carries the shift step through untouched", () => {
+    expect(screenAlignedNudge(BASE, { yawDegrees: 90, pitchDegrees: 35 }, 5, 0)).toEqual({ x: 0, z: -5 });
+    expect(screenAlignedNudge(BASE, { yawDegrees: 180, pitchDegrees: 35 }, 0, 5)).toEqual({ x: 0, z: -5 });
+  });
+
+  it("leaves a workplane laid on a face on its own axes", () => {
+    const onAFace = placementWorkplaneFromSurface({ x: 0, y: 10, z: 0 }, { x: 0, y: 0, z: 1 }, { x: 1, y: 0, z: 0 });
+    for (const yawDegrees of [0, 90, 180, -90]) {
+      expect(screenAlignedNudge(onAFace, { yawDegrees, pitchDegrees: 35 }, 1, 0)).toEqual({ x: 1, z: 0 });
+      expect(screenAlignedNudge(onAFace, { yawDegrees, pitchDegrees: 35 }, 0, 1)).toEqual({ x: 0, z: 1 });
+    }
+  });
+
+  it("still follows the camera on a workplane raised parallel to the base", () => {
+    const raised = horizontalPlacementWorkplane(24);
+    expect(screenAlignedNudge(raised, { yawDegrees: 90, pitchDegrees: 35 }, 1, 0)).toEqual({ x: 0, z: -1 });
+  });
+
+  it("falls back to the Front view mapping for a camera orientation it cannot read", () => {
+    expect(screenAlignedNudge(BASE, DEFAULT_CAMERA_ORIENTATION, 1, 0)).toEqual({ x: 1, z: 0 });
+    expect(screenAlignedNudge(BASE, { yawDegrees: Number.NaN, pitchDegrees: 35 }, 1, 0)).toEqual({ x: 1, z: 0 });
+  });
+});
+
+// Reproduces what the viewport does with the camera, then reads the screen axes
+// back out of the matrix three.js built, rather than trusting the derivation.
+function screenAxes(offset: THREE.Vector3, orthographic = false) {
+  const camera = orthographic
+    ? new THREE.OrthographicCamera(-80, 80, 50, -50, 0.1, 6000)
+    : new THREE.PerspectiveCamera(45, 1.6, 0.1, 6000);
+  camera.up.set(0, 1, 0);
+  camera.position.copy(offset);
+  camera.lookAt(0, 0, 0);
+  camera.updateMatrixWorld();
+  const right = new THREE.Vector3().setFromMatrixColumn(camera.matrixWorld, 0);
+  const down = new THREE.Vector3().setFromMatrixColumn(camera.matrixWorld, 1).negate();
+  return { right, down };
+}
+
+function cameraOrientation(offset: THREE.Vector3) {
+  return {
+    yawDegrees: THREE.MathUtils.radToDeg(Math.atan2(offset.x, offset.z)),
+    pitchDegrees: THREE.MathUtils.radToDeg(Math.atan2(offset.y, Math.max(0.001, Math.hypot(offset.x, offset.z)))),
+  };
+}
+
+describe("screenAlignedNudge against the axes three.js actually renders", () => {
+  const views: [string, THREE.Vector3, boolean][] = [
+    ["home", new THREE.Vector3(118, 96, 118), false],
+    ["front", new THREE.Vector3(0, 0, 160), false],
+    ["right", new THREE.Vector3(160, 0, 0), false],
+    ["back", new THREE.Vector3(0, 0, -160), false],
+    ["left", new THREE.Vector3(-160, 0, 0), false],
+    ["top", new THREE.Vector3(0, 160, 0), false],
+    ["bottom", new THREE.Vector3(0, -160, 0), false],
+    ["low back-left", new THREE.Vector3(-90, 20, -140), false],
+    ["from under the front-right", new THREE.Vector3(70, -40, 90), false],
+    ["orthographic home", new THREE.Vector3(118, 96, 118), true],
+    ["orthographic top", new THREE.Vector3(0, 160, 0), true],
+  ];
+
+  for (const [label, offset, orthographic] of views) {
+    it(`picks the closest axis at the ${label} view`, () => {
+      const axes = screenAxes(offset, orthographic);
+      const camera = cameraOrientation(offset);
+
+      for (const [right, down] of [[1, 0], [-1, 0], [0, 1], [0, -1]]) {
+        const step = screenAlignedNudge(BASE, camera, right, down);
+        const moved = new THREE.Vector3(step.x, 0, step.z);
+        const onScreen = axes.right.clone().multiplyScalar(right).add(axes.down.clone().multiplyScalar(down)).setY(0);
+
+        if (onScreen.lengthSq() < 1e-9) {
+          // Camera exactly at eye level: a vertical arrow has no screen-vertical
+          // part at all, so the only sane reading left is "up goes away from the camera".
+          const away = offset.clone().setY(0).normalize().negate();
+          expect(moved.normalize().dot(away)).toBeCloseTo(down === -1 ? 1 : -1, 6);
+          continue;
+        }
+
+        onScreen.normalize();
+        const closest = Math.max(
+          ...[[1, 0], [-1, 0], [0, 1], [0, -1]].map(([x, z]) => new THREE.Vector3(x, 0, z).dot(onScreen)),
+        );
+        expect(moved.normalize().dot(onScreen)).toBeCloseTo(closest, 6);
+        // Never more than 45 degrees away from where the arrow points on screen.
+        expect(moved.normalize().dot(onScreen)).toBeGreaterThan(Math.SQRT1_2 - 1e-9);
+      }
+    });
+  }
+});


### PR DESCRIPTION
Arrow keys step along the world axes no matter where the camera stands. Orbit round to the Left view, press <kbd>→</kbd>, and the shape walks away from you into the screen. The axis is correct; the key is not the one the user pressed.

This makes an arrow move the selection towards the workplane axis **closest to the direction the arrow points on screen** — the camera yaw rounded to the nearest 90°, the way Tinkercad does it.

## Why this is a fix, not a preference

**Nothing changes in the two views people spend most of their time in.**

- **Front view** maps to the same axes as before: right → +X, down → +Z.
- **The default home view** does too. Its yaw is exactly 45°, halfway between two axes, and the tie deliberately rounds to the axis the editor already used. A user who never orbits never sees a difference.

**The step stays on an axis.** No diagonals, ever — only *which* axis changes. Grid snapping, typed coordinates and the 1 mm / 5 mm step are all untouched. There is a test that walks the yaw in 3° increments through two full turns and asserts every result moves along exactly one axis by exactly the whole step.

**Ctrl + ↑/↓ is untouched.** Lift is along world Y, and height does not depend on where you stand, so it must not turn with the camera.

## Corners worth calling out

- **Top and Bottom.** On the pole there is no horizontal offset to read a yaw from, and `atan2(0, 0)` returns `0`. That happens to be the right answer: `THREE.Matrix4.lookAt` breaks the same degenerate tie towards the same axes, so Top view keeps screen-right = +X and screen-down = +Z. Verified against the matrix three.js actually builds, not just derived on paper.
- **Below the horizon** the view is mirrored, so screen-down is flipped. Screen-right is not — it never depends on the pitch.
- **Orthographic camera** shares position, target and up with the perspective one, so it needs nothing extra. Covered by tests anyway.
- **A workplane laid on a face keeps its own axes.** Turning those with the camera would send arrows off the face the workplane was drawn on, so the camera only steers the flat base plane.

## How the camera gets out of the viewport

The viewport did not expose the camera at all — no ref, no event, no prop. It now reports yaw and pitch through an optional `onCameraOrientationChange`, computed by the very helper `syncViewCube` already used (extracted, not duplicated) and emitted from the same throttled branch of the render loop. The editor parks it in a ref, so a moving camera causes no renders. With the callback absent the editor keeps the Front-view mapping, i.e. exactly today's behaviour.

## Tests

`tests/unit/screenAlignedNudge.test.ts`, 26 cases over the pure axis-choice function:

- four compass views, both poles, negative yaw, a full turn either way
- the 45° ties on both sides of zero (44.9 / 45 / 45.1, 135 / 135.1, −45 / −44.9)
- the below-horizon mirror, the shift step, the workplane-on-a-face passthrough
- and a block that compares every answer against the screen axes three.js really builds for that camera — perspective and orthographic — asserting the chosen axis is the closest one and never more than 45° off

`npm test` 290 passed / 47 files, `npm run typecheck` clean, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAoEuBEJyJtkEGapsp6G22
